### PR TITLE
Switch links over to jmespath.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,9 +25,9 @@ using the ``mtdowling/jmespath.php`` package.
     JmesPath\search($expression, $data);
     // Returns: [1, 2, 3]
 
-- `JMESPath documentation <http://jmespath.readthedocs.org/en/latest/>`_
-- `JMESPath Grammar <http://jmespath.readthedocs.org/en/latest/specification.html#grammar>`_
-- `JMESPath Python library <https://github.com/boto/jmespath>`_
+- `JMESPath Tutorial <http://jmespath.org/tutorial.html>`_
+- `JMESPath Grammar <http://jmespath.org/specification.html#grammar>`_
+- `JMESPath Python library <https://github.com/jmespath/jmespath.py>`_
 
 PHP Usage
 =========


### PR DESCRIPTION
Now that we have jmespath.org, the readthedocs links will just
contain docs specific to the python library.  There'a also
a deprecation notice over at
http://jmespath.readthedocs.org/en/latest/specification.html
and I will eventually remove the spec on readthedocs entirely.

Also, the python jmespath implementation was moved over to the
jmespath org and renamed to jmespath.py so I've updated that
link as well.

It might even be worth just linking to the libraries page on
jmespath.org instead of the python implementation.  Up to you.