### PR TITLE
add custom functions feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,8 +120,8 @@ To create custom functions:
 * Create any `callable <http://php.net/manual/en/language.types.callable.php>`_
   structure (loose function or class with functions) that implement your logic.
 * Call ``FnDispatcher::getInstance()->registerCustomFn()`` to register your function.
-  Be aware that there ``registerCustomFn`` calls must be in a global place where they
-  always will be executed.
+  Be aware that these ``registerCustomFn()`` calls must be in a global place if you want
+  to have your functions always available.
 
 Here is an example with a class instance:
 
@@ -150,7 +150,7 @@ As you can see, you can use all the possible ``callable`` structures as defined 
 All those examples will lead to a function ``myFunction()`` that can be used in your expressions.
 
 Type specification
-^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~
 
 The ``FnDispatcher::getInstance()->registerCustomFn()`` function accepts an
 optional third parameter that allows you to pass an array of type specifications
@@ -160,6 +160,7 @@ parameters in the expression will be validated before your ``callable`` is execu
 Example:
 
 .. code-block:: php
+
     $fn->registerCustomFn('myFunction', $callbackFunction, [['number'], ['string']]);
 
 Defines that your function expects exactly 2 parameters, the first being a ``number`` and

--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,72 @@ You can utilize the CompilerRuntime in ``JmesPath\search()`` by setting
 the ``JP_PHP_COMPILE`` environment variable to "on" or to a directory
 on disk used to store cached expressions.
 
+Custom functions
+----------------
+
+The JMESPath language has numerous
+`built-in functions
+<http://jmespath.org/specification.html#built-in-functions>`__, but it is
+also possible to add your own custom functions.  Keep in mind that
+custom function support in jmespath.php is experimental and the API may
+change based on feedback.
+
+**If you have a custom function that you've found useful, consider submitting
+it to jmespath.site and propose that it be added to the JMESPath language.**
+You can submit proposals
+`here <https://github.com/jmespath/jmespath.site/issues>`__.
+
+To create custom functions:
+
+* Create any `callable <http://php.net/manual/en/language.types.callable.php>`_
+  structure (loose function or class with functions) that implement your logic.
+* Call ``FnDispatcher::getInstance()->registerCustomFn()`` to register your function.
+  Be aware that there ``registerCustomFn`` calls must be in a global place where they
+  always will be executed.
+
+Here is an example with a class instance:
+
+.. code-block:: php
+
+    // Create a class that contains your function
+    class CustomFunctionHandler
+    {
+        public function double($args)
+        {
+            return $args[0] * 2;
+        }
+    }
+    FnDispatcher::getInstance()->registerCustomFn('myFunction', [new CustomFunctionHandler(), 'double'])
+
+An example with a runtime function:
+
+.. code-block:: php
+
+    $callbackFunction = function ($args) {
+        return $args[0];
+    };
+    $fn->registerCustomFn('myFunction', $callbackFunction);
+
+As you can see, you can use all the possible ``callable`` structures as defined in the PHP documentation.
+All those examples will lead to a function ``myFunction()`` that can be used in your expressions.
+
+Type specification
+^^^^^^^^^^^^^^^^^^
+
+The ``FnDispatcher::getInstance()->registerCustomFn()`` function accepts an
+optional third parameter that allows you to pass an array of type specifications
+for your custom function. If you pass this, the types (and count) of the passed
+parameters in the expression will be validated before your ``callable`` is executed.
+
+Example:
+
+.. code-block:: php
+    $fn->registerCustomFn('myFunction', $callbackFunction, [['number'], ['string']]);
+
+Defines that your function expects exactly 2 parameters, the first being a ``number`` and
+the second being a ``string``. If anything else is passed in the call to your function,
+a ``\RuntimeException`` will be thrown.
+
 Testing
 =======
 

--- a/src/FnDispatcher.php
+++ b/src/FnDispatcher.php
@@ -27,7 +27,7 @@ class FnDispatcher
      */
     public static function getInstance()
     {
-        if (self::$instance) {
+        if (!self::$instance) {
             self::$instance = new self();
         }
 

--- a/tests/FnDispatcherTest.php
+++ b/tests/FnDispatcherTest.php
@@ -17,6 +17,28 @@ class FnDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $fn('to_string', [new _TestStringClass()]));
         $this->assertEquals('"foo"', $fn('to_string', [new _TestJsonStringClass()]));
     }
+
+    public function testCustomFunctions()
+    {
+        $callable = new _TestCustomFunctionCallable();
+
+        $fn = new FnDispatcher();
+        $fn->registerCustomFn('double', [$callable, 'double']);
+        $fn->registerCustomFn('testSuffix', [$callable, 'testSuffix']);
+        $fn->registerCustomFn('testTypeValidation', [$callable, 'testTypeValidation'], [['number'], ['number']]);
+
+        $this->assertEquals(4, $fn('double', [2]));
+        $this->assertEquals('someStringTest', $fn('testSuffix', ['someString']));
+
+        // check type validation
+        try {
+            $this->assertEquals(2, $fn('testTypeValidation', [1, '1']));
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\RuntimeException', $e);
+        }
+
+        $this->assertEquals(4, $fn('testTypeValidation', [2, 2]));
+    }
 }
 
 class _TestStringClass
@@ -37,5 +59,23 @@ class _TestJsonStringClass implements \JsonSerializable
     public function jsonSerialize()
     {
         return 'foo';
+    }
+}
+
+class _TestCustomFunctionCallable
+{
+    public function double($args)
+    {
+        return $args[0] * 2;
+    }
+
+    public function testSuffix($args)
+    {
+        return $args[0].'Test';
+    }
+
+    public function testTypeValidation($args)
+    {
+        return $args[0] + $args[1];
     }
 }


### PR DESCRIPTION
Hello ;-)

With envy I have seen that `jmespath.py` added a *custom function* feature in jmespath/jmespath.py#102 - and that is something I need for the PHP implementation too ;-) so I created this PR that should add this feature - I also added tests and documentation.

let me know if anything is missing.

PS: I also changed the singleton handling a bit in `FnDispatcher` as IMHO the instance should be a defined static class property, not implicitly created in the `getInstance()` method.