### PR TITLE
Allow PHP objects to be supported by JmesPath.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,12 @@
     "files": ["src/JmesPath.php"]
   },
 
+  "autoload-dev": {
+    "psr-4": {
+      "JmesPath\\Tests\\": "tests/"
+    }
+  },
+
   "bin": ["bin/jp.php"],
 
   "extra": {

--- a/src/JmesPathableArrayInterface.php
+++ b/src/JmesPathableArrayInterface.php
@@ -1,0 +1,6 @@
+<?php
+namespace JmesPath;
+
+interface JmesPathableArrayInterface extends \ArrayAccess, \Countable, \Iterator
+{
+}

--- a/src/JmesPathableObjectInterface.php
+++ b/src/JmesPathableObjectInterface.php
@@ -1,0 +1,11 @@
+<?php
+namespace JmesPath;
+
+interface JmesPathableObjectInterface
+{
+    public function __get($name);
+    public function __set($name, $value);
+    public function __isset($name);
+    public function __toString();
+    public function toArray();
+}

--- a/src/TreeCompiler.php
+++ b/src/TreeCompiler.php
@@ -107,7 +107,7 @@ class TreeCompiler
         return $this
             ->write('%s = $value;', $a)
             ->dispatch($node['children'][0])
-            ->write('if (!$value && $value !== "0" && $value !== 0) {')
+            ->write('if (!Utils::isTruthy($value)) {')
                 ->indent()
                 ->write('$value = %s;', $a)
                 ->dispatch($node['children'][1])
@@ -121,7 +121,7 @@ class TreeCompiler
         return $this
             ->write('%s = $value;', $a)
             ->dispatch($node['children'][0])
-            ->write('if ($value || $value === "0" || $value === 0) {')
+            ->write('if (Utils::isTruthy($value)) {')
                 ->indent()
                 ->write('$value = %s;', $a)
                 ->dispatch($node['children'][1])
@@ -157,7 +157,7 @@ class TreeCompiler
                 ->indent()
                 ->write('$value = isset(%s) ? %s : null;', $arr, $arr)
                 ->outdent()
-            ->write('} elseif ($value instanceof \\stdClass) {')
+            ->write('} elseif ($value instanceof \\stdClass || $value instanceof JmesPath\\JmesPathableObjectInterface) {')
                 ->indent()
                 ->write('$value = isset(%s) ? %s : null;', $obj, $obj)
                 ->outdent()
@@ -266,7 +266,7 @@ class TreeCompiler
     {
         return $this
             ->write('$value = !is_string($value) && !Utils::isArray($value)')
-            ->write('    ? null : Utils::slice($value, %s, %s, %s);',
+            ->write('    ? null : Utils::slice(Utils::toArray($value), %s, %s, %s);',
                 var_export($node['value'][0], true),
                 var_export($node['value'][1], true),
                 var_export($node['value'][2], true)
@@ -305,6 +305,7 @@ class TreeCompiler
                 ->write('%s = [];', $merged)
                 ->write('foreach ($value as %s) {', $val)
                     ->indent()
+                    ->write('%s = Utils::toArray(%s);', $val, $val)
                     ->write('if (is_array(%s) && isset(%s[0])) {', $val, $val)
                         ->indent()
                         ->write('%s = array_merge(%s, %s);', $merged, $merged, $val)
@@ -342,7 +343,7 @@ class TreeCompiler
         $this->write('if ($value !== null) {')
             ->indent()
             ->write('%s = [];', $collected)
-            ->write('foreach ((array) $value as %s) {', $val)
+            ->write('foreach ((array) Utils::toArray($value) as %s) {', $val)
                 ->indent()
                 ->write('$value = %s;', $val)
                 ->dispatch($node['children'][1])

--- a/src/TreeInterpreter.php
+++ b/src/TreeInterpreter.php
@@ -47,7 +47,7 @@ class TreeInterpreter
             case 'field':
                 if (is_array($value) || $value instanceof \ArrayAccess) {
                     return isset($value[$node['value']]) ? $value[$node['value']] : null;
-                } elseif ($value instanceof \stdClass) {
+                } elseif ($value instanceof \stdClass || $value instanceof JmesPathableObjectInterface) {
                     return isset($value->{$node['value']}) ? $value->{$node['value']} : null;
                 }
                 return null;
@@ -87,7 +87,7 @@ class TreeInterpreter
                 }
 
                 $collected = [];
-                foreach ((array) $left as $val) {
+                foreach ((array) Utils::toArray($left) as $val) {
                     $result = $this->dispatch($node['children'][1], $val);
                     if ($result !== null) {
                         $collected[] = $result;
@@ -106,6 +106,7 @@ class TreeInterpreter
 
                 $merged = [];
                 foreach ($value as $values) {
+                    $values = Utils::toArray($values);
                     // Only merge up arrays lists and not hashes
                     if (is_array($values) && isset($values[0])) {
                         $merged = array_merge($merged, $values);
@@ -198,7 +199,7 @@ class TreeInterpreter
             case 'slice':
                 return is_string($value) || Utils::isArray($value)
                     ? Utils::slice(
-                        $value,
+                        Utils::toArray($value),
                         $node['value'][0],
                         $node['value'][1],
                         $node['value'][2]

--- a/tests/ArrayLike.php
+++ b/tests/ArrayLike.php
@@ -1,0 +1,70 @@
+<?php
+namespace JmesPath\Tests;
+
+use JmesPath\JmesPathableArrayInterface;
+
+class ArrayLike implements JmesPathableArrayInterface
+{
+    private $data = [];
+
+    private $position = 0;
+
+    public function __construct(array $data = [])
+    {
+        $this->data = $data;
+    }
+
+    public function offsetExists($offset)
+    {
+        return array_key_exists($offset, $this->data);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->offsetExists($offset) ? $this->data[$offset] : null;
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        if (is_null($offset)) {
+            $this->data[] = $value;
+        } else {
+            $this->data[$offset] = $value;
+        }
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->data[$offset]);
+    }
+
+    public function count()
+    {
+        return count($this->data);
+    }
+
+    public function current()
+    {
+        return $this->offsetGet($this->position);
+    }
+
+    public function key()
+    {
+        return $this->position;
+    }
+
+    public function next()
+    {
+        $this->position++;
+    }
+
+    public function rewind()
+    {
+        $this->position = 0;
+    }
+
+    public function valid()
+    {
+        return $this->offsetExists($this->position);
+    }
+}

--- a/tests/FnDispatcherTest.php
+++ b/tests/FnDispatcherTest.php
@@ -5,7 +5,291 @@ use JmesPath\FnDispatcher;
 
 class FnDispatcherTest extends \PHPUnit_Framework_TestCase
 {
-    public function testConvertsToString()
+    public function testAbs()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals(1, $fn('abs', [1]));
+    }
+
+    public function testAvg()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals(2, $fn('avg', [[1, 2, 3]]));
+        $this->assertEquals(2, $fn('avg', [new ArrayLike([1, 2, 3])]));
+    }
+
+    public function testCeil()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals(1.0, $fn('ceil', [0.5]));
+    }
+
+    public function testContains()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals(true, $fn('contains', ['foo', 'foo']));
+        $this->assertEquals(false, $fn('contains', ['foo', 'bar']));
+        $this->assertEquals(true, $fn('contains', [[1, 2, 3], 2]));
+        $this->assertEquals(false, $fn('contains', [[1, 2, 3], 4]));
+        $this->assertEquals(true, $fn('contains', [new ArrayLike([1, 2, 3]), 2]));
+        $this->assertEquals(false, $fn('contains', [new ArrayLike([1, 2, 3]), 4]));
+    }
+    
+    public function testEndsWith()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals(true, $fn('ends_with', ['foobar', 'bar']));
+        $this->assertEquals(false, $fn('ends_with', ['foobar', 'foo']));
+    }
+
+    public function testFloor()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals(0, $fn('floor', [0.5]));
+    }
+
+    public function testNotNull()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals(1, $fn('not_null', [1, null, 3]));
+    }
+
+    public function testJoin()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals('a,b', $fn('join', [',', ['a', 'b']]));
+        $this->assertEquals('a,b', $fn('join', [',', new ArrayLike(['a', 'b'])]));
+    }
+
+    public function testKeys()
+    {
+        $fn = new FnDispatcher();
+        $obj = new \stdClass;
+        $obj->foo = 'foo';
+        $obj->bar = 'bar';
+        $this->assertEquals(['foo', 'bar'], $fn('keys', [$obj]));
+        $obj = new StdClassLike;
+        $obj->foo = 'foo';
+        $obj->bar = 'bar';
+        $this->assertEquals(['foo', 'bar'], $fn('keys', [$obj]));
+    }
+
+    public function testLength()
+    {
+        $fn = new FnDispatcher();
+        $obj = new \stdClass;
+        $obj->foo = 'foo';
+        $obj->bar = 'bar';
+        $this->assertEquals(2, $fn('length', [$obj]));
+        $this->assertEquals(3, $fn('length', ['foo']));
+        $this->assertEquals(3, $fn('length', [[1, 2, 3]]));
+        $this->assertEquals(3, $fn('length', [new ArrayLike([1, 2, 3])]));
+        $obj = new StdClassLike;
+        $obj->foo = 'foo';
+        $obj->bar = 'bar';
+        $this->assertEquals(2, $fn('length', [$obj]));
+    }
+
+    public function testMax()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals('foo', $fn('max', [['foo', 'a']]));
+        $this->assertEquals(3, $fn('max', [[1, 2, 3]]));
+        $this->assertEquals('foo', $fn('max', [new ArrayLike(['foo', 'a'])]));
+        $this->assertEquals(3, $fn('max', [new ArrayLike([1, 2, 3])]));
+    }
+
+    public function testMaxBy()
+    {
+        $fn = new FnDispatcher();
+        $person1 = new \stdClass;
+        $person1->age = 40;
+        $person1->ageStr = '40';
+        $person2 = new \stdClass;
+        $person2->age = 50;
+        $person2->ageStr = '50';
+        $this->assertEquals($person2, $fn('max_by', [[$person1, $person2], function ($person) {
+            return $person->age;
+        }]));
+        $this->assertEquals($person2, $fn('max_by', [new ArrayLike([$person1, $person2]), function ($person) {
+            return $person->age;
+        }]));
+        $this->assertEquals('foo', $fn('max_by', [['foo', 'a'], function ($item) {
+            return strlen($item);
+        }]));
+        $this->assertEquals(3, $fn('max_by', [[1, 2, 3], function ($item) {
+            return $item;
+        }]));
+        $this->assertEquals('foo', $fn('max_by', [new ArrayLike(['foo', 'a']), function ($item) {
+            return strlen($item);
+        }]));
+        $this->assertEquals(3, $fn('max_by', [new ArrayLike([1, 2, 3]), function ($item) {
+            return $item;
+        }]));
+        $person1 = new StdClassLike;
+        $person1->age = 40;
+        $person1->ageStr = '40';
+        $person2 = new StdClassLike;
+        $person2->age = 50;
+        $person2->ageStr = '50';
+        $this->assertEquals($person2, $fn('max_by', [[$person1, $person2], function ($person) {
+            return $person->age;
+        }]));
+        $this->assertEquals($person2, $fn('max_by', [new ArrayLike([$person1, $person2]), function ($person) {
+            return $person->age;
+        }]));
+    }
+
+    public function testMin()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals('a', $fn('min', [['foo', 'a']]));
+        $this->assertEquals(1, $fn('min', [[1, 2, 3]]));
+        $this->assertEquals('a', $fn('min', [new ArrayLike(['foo', 'a'])]));
+        $this->assertEquals(1, $fn('min', [new ArrayLike([1, 2, 3])]));
+    }
+
+    public function testMinBy()
+    {
+        $fn = new FnDispatcher();
+        $person1 = new \stdClass;
+        $person1->age = 40;
+        $person1->ageStr = '40';
+        $person2 = new \stdClass;
+        $person2->age = 50;
+        $person2->ageStr = '50';
+        $this->assertEquals($person1, $fn('min_by', [[$person1, $person2], function ($person) {
+            return $person->age;
+        }]));
+        $this->assertEquals($person1, $fn('min_by', [new ArrayLike([$person1, $person2]), function ($person) {
+            return $person->age;
+        }]));
+        $this->assertEquals('a', $fn('min_by', [['foo', 'a'], function ($item) {
+            return strlen($item);
+        }]));
+        $this->assertEquals(1, $fn('min_by', [[1, 2, 3], function ($item) {
+            return $item;
+        }]));
+        $this->assertEquals('a', $fn('min_by', [new ArrayLike(['foo', 'a']), function ($item) {
+            return strlen($item);
+        }]));
+        $this->assertEquals(1, $fn('min_by', [new ArrayLike([1, 2, 3]), function ($item) {
+            return $item;
+        }]));
+        $person1 = new StdClassLike;
+        $person1->age = 40;
+        $person1->ageStr = '40';
+        $person2 = new StdClassLike;
+        $person2->age = 50;
+        $person2->ageStr = '50';
+        $this->assertEquals($person1, $fn('min_by', [[$person1, $person2], function ($person) {
+            return $person->age;
+        }]));
+        $this->assertEquals($person1, $fn('min_by', [new ArrayLike([$person1, $person2]), function ($person) {
+            return $person->age;
+        }]));
+    }
+
+    public function testReverse()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals('oof', $fn('reverse', ['foo']));
+        $this->assertEquals([3, 2, 1], $fn('reverse', [[1, 2, 3]]));
+        $this->assertEquals([3, 2, 1], $fn('reverse', [new ArrayLike([1, 2, 3])]));
+    }
+
+    public function testSum()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals(6, $fn('sum', [[1, 2, 3]]));
+        $this->assertEquals(6, $fn('sum', [new ArrayLike([1, 2, 3])]));
+    }
+
+    public function testSort()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals([1, 2, 3], $fn('sort', [[3, 1, 2]]));
+        $this->assertEquals(['a', 'b', 'c'], $fn('sort', [['c', 'a', 'b']]));
+        $this->assertEquals([1, 2, 3], $fn('sort', [new ArrayLike([3, 1, 2])]));
+        $this->assertEquals(['a', 'b', 'c'], $fn('sort', [new ArrayLike(['c', 'a', 'b'])]));
+    }
+
+    public function testSortBy()
+    {
+        $fn = new FnDispatcher();
+        $person1 = new \stdClass;
+        $person1->age = 50;
+        $person1->name = 'foo';
+        $person2 = new \stdClass;
+        $person2->age = 40;
+        $person2->name = 'bar';
+        $this->assertEquals([$person2, $person1], $fn('sort_by', [[$person1, $person2], function ($person) {
+            return $person->age;
+        }]));
+        $this->assertEquals([$person2, $person1], $fn('sort_by', [[$person1, $person2], function ($person) {
+            return $person->name;
+        }]));
+        $this->assertEquals([$person2, $person1], $fn('sort_by', [new ArrayLike([$person1, $person2]), function ($person) {
+            return $person->age;
+        }]));
+        $this->assertEquals([$person2, $person1], $fn('sort_by', [new ArrayLike([$person1, $person2]), function ($person) {
+            return $person->name;
+        }]));
+        $this->assertEquals([1, 2, 3], $fn('sort_by', [[3, 1, 2], function ($item) {
+            return $item;
+        }]));
+        $this->assertEquals(['a', 'b', 'c'], $fn('sort_by', [['c', 'a', 'b'], function ($item) {
+            return $item;
+        }]));
+        $this->assertEquals([1, 2, 3], $fn('sort_by', [new ArrayLike([3, 1, 2]), function ($item) {
+            return $item;
+        }]));
+        $this->assertEquals(['a', 'b', 'c'], $fn('sort_by', [new ArrayLike(['c', 'a', 'b']), function ($item) {
+            return $item;
+        }]));
+        $person1 = new StdClassLike;
+        $person1->age = 50;
+        $person1->name = 'foo';
+        $person2 = new StdClassLike;
+        $person2->age = 40;
+        $person2->name = 'bar';
+        $this->assertEquals([$person2, $person1], $fn('sort_by', [[$person1, $person2], function ($person) {
+            return $person->age;
+        }]));
+        $this->assertEquals([$person2, $person1], $fn('sort_by', [[$person1, $person2], function ($person) {
+            return $person->name;
+        }]));
+        $this->assertEquals([$person2, $person1], $fn('sort_by', [new ArrayLike([$person1, $person2]), function ($person) {
+            return $person->age;
+        }]));
+        $this->assertEquals([$person2, $person1], $fn('sort_by', [new ArrayLike([$person1, $person2]), function ($person) {
+            return $person->name;
+        }]));
+    }
+
+    public function testStartsWith()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals(true, $fn('starts_with', ['foobar', 'foo']));
+        $this->assertEquals(false, $fn('starts_with', ['barfoo', 'foo']));
+    }
+
+    public function testType()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals('boolean', $fn('type', [true]));
+        $this->assertEquals('string', $fn('type', ['foo']));
+        $this->assertEquals('null', $fn('type', [null]));
+        $this->assertEquals('number', $fn('type', [(double)3]));
+        $this->assertEquals('number', $fn('type', [(integer)3]));
+        $this->assertEquals('number', $fn('type', [(float)3]));
+        $this->assertEquals('array', $fn('type', [[]]));
+        $this->assertEquals('object', $fn('type', [new \stdClass]));
+        $this->assertEquals('array', $fn('type', [new ArrayLike([])]));
+        $this->assertEquals('object', $fn('type', [new StdClassLike]));
+    }
+
+    public function testToString()
     {
         $fn = new FnDispatcher();
         $this->assertEquals('foo', $fn('to_string', ['foo']));
@@ -16,7 +300,69 @@ class FnDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{"foo":"bar"}', $fn('to_string', [$std]));
         $this->assertEquals('foo', $fn('to_string', [new _TestStringClass()]));
         $this->assertEquals('"foo"', $fn('to_string', [new _TestJsonStringClass()]));
+        $this->assertEquals('["foo"]', $fn('to_string', [new ArrayLike(['foo'])]));
+        $std = new StdClassLike();
+        $std->foo = 'bar';
+        $this->assertEquals('{"foo":"bar"}', $fn('to_string', [$std]));
     }
+
+    public function testToNumber()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals(1, $fn('to_number', [1]));
+        $this->assertEquals(1, $fn('to_number', ['1']));
+        $this->assertEquals(1.23, $fn('to_number', [1.23]));
+        $this->assertEquals(1.23, $fn('to_number', ['1.23']));
+        $this->assertEquals(null, $fn('to_number', ['foo']));
+        $this->assertEquals(null, $fn('to_number', ['1.23foo']));
+    }
+
+    public function testValues()
+    {
+        $fn = new FnDispatcher();
+        $obj = new \stdClass;
+        $obj->foo = 'foo';
+        $obj->bar = 'bar';
+        $this->assertEquals(['foo', 'bar'], $fn('values', [$obj]));
+        $this->assertEquals(['foo', 'bar'], $fn('values', [['foo', 'bar']]));
+        $this->assertEquals(['foo', 'bar'], $fn('values', [new ArrayLike(['foo', 'bar'])]));
+        $obj = new StdClassLike;
+        $obj->foo = 'foo';
+        $obj->bar = 'bar';
+        $this->assertEquals(['foo', 'bar'], $fn('values', [$obj]));
+    }
+
+    public function testMerge()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals(['foo', 'bar'], $fn('merge', [['1', 'bar'], ['foo']]));
+        $this->assertEquals(['foo', 'bar'], $fn('merge', [new ArrayLike(['foo', 'bar']), new ArrayLike(['foo'])]));
+        $this->assertEquals(['foo', 'bar'], $fn('merge', [['1', 'bar'], new ArrayLike(['foo'])]));
+    }
+
+    public function testToArray()
+    {
+        $fn = new FnDispatcher();
+        $obj = new \stdClass;
+        $obj->foo = 'foo';
+        $obj->bar = 'bar';
+        $this->assertEquals([$obj], $fn('to_array', [$obj]));
+        $this->assertEquals(['foo', 'bar'], $fn('to_array', [['foo', 'bar']]));
+        $this->assertEquals(['foo', 'bar'], $fn('to_array', [new ArrayLike(['foo', 'bar'])]));
+        $obj = new StdClassLike;
+        $obj->foo = 'foo';
+        $obj->bar = 'bar';
+        $this->assertEquals([$obj], $fn('to_array', [$obj]));
+    }
+
+    public function testMap()
+    {
+        $fn = new FnDispatcher();
+        $this->assertEquals(['foo', 'bar'], $fn('map', [function ($item) {
+            return $item;
+        }, ['foo', 'bar']]));
+    }
+
 }
 
 class _TestStringClass

--- a/tests/StdClassLike.php
+++ b/tests/StdClassLike.php
@@ -1,0 +1,56 @@
+<?php
+namespace JmesPath\Tests;
+
+use JmesPath\JmesPathableObjectInterface;
+
+class StdClassLike implements JmesPathableObjectInterface
+{
+    private $values = [];
+
+    public function __get($name)
+    {
+        return $this->values[$name];
+    }
+
+    public function __set($name, $value)
+    {
+        $this->values[$name] = $value;
+    }
+
+    public function __isset($name)
+    {
+        return array_key_exists($name, $this->values);
+    }
+
+    public function toArray()
+    {
+        $array = [];
+
+        foreach ($this->values as $name => $value) {
+            if ($value instanceof ArrayLike) {
+                $array[$name] = [];
+                foreach ($value as $property) {
+                    $array[$name][] = self::propertyToArrayValue($property);
+                }
+            } else {
+                $array[$name] = self::propertyToArrayValue($value);
+            }
+        }
+
+        return $array;
+    }
+
+    private static function propertyToArrayValue($value)
+    {
+        if ($value instanceof StdClassLike) {
+            return $value->toArray();
+        } else {
+            return $value;
+        }
+    }
+
+    public function __toString()
+    {
+        return json_encode($this->toArray());
+    }
+}

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -21,7 +21,9 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
             [new \ArrayObject(), 'array'],
             [new \ArrayObject([1, 2]), 'array'],
             [new \ArrayObject(['foo' => 'bar']), 'object'],
-            [new _TestStr(), 'string']
+            [new _TestStr(), 'string'],
+            [new ArrayLike(), 'array'],
+            [new StdClassLike(), 'object']
         ];
     }
 
@@ -50,7 +52,10 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
             [new _TestClass(), false],
             [new \ArrayObject(['a' => 'b']), false],
             [new \ArrayObject([1]), true],
-            [new \stdClass(), false]
+            [new \stdClass(), false],
+            [new ArrayLike(['a' => 'b']), false],
+            [new ArrayLike([1]), true],
+            [new StdClassLike(), false]
         ];
     }
 
@@ -71,7 +76,10 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
             [new _TestClass(), false],
             [new \ArrayObject(['a' => 'b']), true],
             [new \ArrayObject([1]), false],
-            [new \stdClass(), true]
+            [new \stdClass(), true],
+            [new ArrayLike(['a' => 'b']), true],
+            [new ArrayLike([1]), false],
+            [new StdClassLike(), true]
         ];
     }
 
@@ -103,6 +111,9 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([3, 2, 1], Utils::slice([1, 2, 3], null, null, -1));
         $this->assertEquals([1, 3], Utils::slice([1, 2, 3], null, null, 2));
         $this->assertEquals([2, 3], Utils::slice([1, 2, 3], 1));
+        $this->assertEquals([3, 2, 1], Utils::slice(new ArrayLike([1, 2, 3]), null, null, -1));
+        $this->assertEquals([1, 3], Utils::slice(new ArrayLike([1, 2, 3]), null, null, 2));
+        $this->assertEquals([2, 3], Utils::slice(new ArrayLike([1, 2, 3]), 1));
     }
 
     public function testSlicesStrings()
@@ -110,6 +121,64 @@ class UtilsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('cba', Utils::slice('abc', null, null, -1));
         $this->assertEquals('ac', Utils::slice('abc', null, null, 2));
         $this->assertEquals('bc', Utils::slice('abc', 1));
+    }
+
+    public function testChecksIfTruthy()
+    {
+        $this->assertEquals(true, Utils::isTruthy(true));
+        $this->assertEquals(false, Utils::isTruthy(false));
+        $this->assertEquals(true, Utils::isTruthy(0));
+        $this->assertEquals(true, Utils::isTruthy('0'));
+        $obj = new \stdClass;
+        $obj->foo = 'foo';
+        $obj->bar = 'bar';
+        $this->assertEquals(true, Utils::isTruthy($obj));
+        $obj = new \stdClass;
+        $this->assertEquals(false, Utils::isTruthy($obj));
+        $this->assertEquals(false, Utils::isTruthy([]));
+        $this->assertEquals(true, Utils::isTruthy(['foo']));
+        $this->assertEquals(false, Utils::isTruthy(new ArrayLike([])));
+        $this->assertEquals(true, Utils::isTruthy(new ArrayLike(['foo'])));
+        $obj = new StdClassLike;
+        $obj->foo = 'foo';
+        $obj->bar = 'bar';
+        $this->assertEquals(true, Utils::isTruthy($obj));
+        $obj = new StdClassLike;
+        $this->assertEquals(false, Utils::isTruthy($obj));
+    }
+
+    public function testChecksIsEqual()
+    {
+        $this->assertEquals(true, Utils::isEqual(true, true));
+        $this->assertEquals(true, Utils::isEqual(false, false));
+        $this->assertEquals(true, Utils::isEqual(1, 1));
+        $this->assertEquals(true, Utils::isEqual('foo', 'foo'));
+        $a = new \stdClass;
+        $a->foo = 'foo';
+        $b = new \stdClass;
+        $b->foo = 'foo';
+        $this->assertEquals(true, Utils::isEqual($a, $b));
+        $a = new \stdClass;
+        $a->foo = 'foo';
+        $b = new \stdClass;
+        $b->foo = 'bar';
+        $this->assertEquals(false, Utils::isEqual($a, $b));
+        $this->assertEquals(true, Utils::isEqual([], []));
+        $this->assertEquals(true, Utils::isEqual(['foo'], ['foo']));
+        $this->assertEquals(false, Utils::isEqual(['foo'], ['bar']));
+        $this->assertEquals(true, Utils::isEqual(new ArrayLike([]), new ArrayLike([])));
+        $this->assertEquals(true, Utils::isEqual(new ArrayLike(['foo']), new ArrayLike(['foo'])));
+        $this->assertEquals(false, Utils::isEqual(new ArrayLike(['foo']), new ArrayLike(['bar'])));
+        $a = new StdClassLike;
+        $a->foo = 'foo';
+        $b = new StdClassLike;
+        $b->foo = 'foo';
+        $this->assertEquals(true, Utils::isEqual($a, $b));
+        $a = new StdClassLike;
+        $a->foo = 'foo';
+        $b = new StdClassLike;
+        $b->foo = 'bar';
+        $this->assertEquals(false, Utils::isEqual($a, $b));
     }
 }
 


### PR DESCRIPTION
This adds support for PHP objects that are not `\Array` or `\stdClass`.

Provided your classes implement either `JmesPathableObjectInterface` or `JmesPathableArrayInterface` you will be able use JMESPath expressions to extract information from objects derived from them. The small example below hopefully provides an explanation.

``` php
$product1 = new StdClassLike();
$product1->title = 'Item One';
$product1->price = 4.99;

$product2 = new StdClassLike();
$product2->title = 'Item Two';
$product2->price = 9.99;

$basket = new StdClassLike();
$basket->items = new ArrayLike([
    $product1,
    $product2
]);

$result = JmesPath\Env::search('max_by(items, &price)', $basket);
var_dump($result);

/*
    object(StdClassLike)#7 (1) {
      ["values":"StdClassLike":private]=>
      array(2) {
        ["title"]=>
        string(8) "Item Two"
        ["price"]=>
        float(9.99)
      }
    }
*/
```

Two gists show how `StdClassLike` and `ArrayLike` are implemented.
- [StdClassLike](https://gist.github.com/davidtsadler/cd2e09dbc4455541093f22c3686d4834)
- [ArrayLike](https://gist.github.com/davidtsadler/479786334dbeb3bc8c4d0e80123e4d46)

I've updated the [compliance test](https://github.com/davidtsadler/jmespath.php/blob/support-php-objects/tests/ComplianceTest.php#L114) so that another pass is made through the test suites. This extra pass rebuilds the json [as PHP objects](https://github.com/davidtsadler/jmespath.php/blob/support-php-objects/tests/ComplianceTest.php#L164) before running the compliance test. Extra tests have also been added to cover the changes made to the code.

I perfectly understand if these changes won't be accepted. JMESPath is primarily for extracting information from json. Providing the same functionality for PHP objects may be outside of it's scope and there may not be enough interest from PHP developers to justify maintaining the code. 
