### PR TITLE
PHP 7.4 deprecates reverse order of implode parameters (detected by P…

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -224,6 +224,6 @@ class Utils
             }
         }
 
-        return $type == 'string' ? implode($result, '') : $result;
+        return $type == 'string' ? implode('', $result) : $result;
     }
 }


### PR DESCRIPTION
PHP 7.4 deprecates reverse order of implode parameters (detected by PHPCompatibility)