### PR TITLE
Code style fixes

### DIFF
--- a/src/FnDispatcher.php
+++ b/src/FnDispatcher.php
@@ -118,7 +118,9 @@ class FnDispatcher
     private function fn_max(array $args)
     {
         $this->validate('max', $args, [['array']]);
-        $fn = function ($a, $b) { return $a >= $b ? $a : $b; };
+        $fn = function ($a, $b) {
+            return $a >= $b ? $a : $b;
+        };
         return $this->reduce('max:0', $args[0], ['number', 'string'], $fn);
     }
 
@@ -137,7 +139,9 @@ class FnDispatcher
     private function fn_min(array $args)
     {
         $this->validate('min', $args, [['array']]);
-        $fn = function ($a, $b, $i) { return $i && $a <= $b ? $a : $b; };
+        $fn = function ($a, $b, $i) {
+            return $i && $a <= $b ? $a : $b;
+        };
         return $this->reduce('min:0', $args[0], ['number', 'string'], $fn);
     }
 
@@ -167,7 +171,9 @@ class FnDispatcher
     private function fn_sum(array $args)
     {
         $this->validate('sum', $args, [['array']]);
-        $fn = function ($a, $b) { return $a + $b; };
+        $fn = function ($a, $b) {
+            return $a + $b;
+        };
         return $this->reduce('sum:0', $args[0], ['number'], $fn);
     }
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -142,7 +142,8 @@ class Parser
         return ['type' => T::T_NOT, 'children' => [$this->expr(self::$bp[T::T_NOT])]];
     }
 
-    private function nud_lparen() {
+    private function nud_lparen()
+    {
         $this->next();
         $result = $this->expr(0);
         if ($this->token['type'] !== T::T_RPAREN) {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -3,7 +3,7 @@ namespace JmesPath;
 
 class Utils
 {
-    static $typeMap = [
+    public static $typeMap = [
         'boolean' => 'boolean',
         'string'  => 'string',
         'NULL'    => 'null',
@@ -140,14 +140,18 @@ class Utils
     public static function stableSort(array $data, callable $sortFn)
     {
         // Decorate each item by creating an array of [value, index]
-        array_walk($data, function (&$v, $k) { $v = [$v, $k]; });
+        array_walk($data, function (&$v, $k) {
+            $v = [$v, $k];
+        });
         // Sort by the sort function and use the index as a tie-breaker
         uasort($data, function ($a, $b) use ($sortFn) {
             return $sortFn($a[0], $b[0]) ?: ($a[1] < $b[1] ? -1 : 1);
         });
 
         // Undecorate each item and return the resulting sorted array
-        return array_map(function ($v) { return $v[0]; }, array_values($data));
+        return array_map(function ($v) {
+            return $v[0];
+        }, array_values($data));
     }
 
     /**

--- a/tests/EnvTest.php
+++ b/tests/EnvTest.php
@@ -9,14 +9,14 @@ class EnvTest extends TestCase
 {
     public function testSearchesInput()
     {
-        $data = array('foo' => 123);
+        $data = ['foo' => 123];
         $this->assertEquals(123, Env::search('foo', $data));
         $this->assertEquals(123, Env::search('foo', $data));
     }
 
     public function testSearchesWithFunction()
     {
-        $data = array('foo' => 123);
+        $data = ['foo' => 123];
         $this->assertEquals(123, \JmesPath\search('foo', $data));
     }
 

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -12,36 +12,36 @@ class LexerTest extends TestCase
 {
     public function inputProvider()
     {
-        return array(
-            array('0', 'number'),
-            array('1', 'number'),
-            array('2', 'number'),
-            array('3', 'number'),
-            array('4', 'number'),
-            array('5', 'number'),
-            array('6', 'number'),
-            array('7', 'number'),
-            array('8', 'number'),
-            array('9', 'number'),
-            array('-1', 'number'),
-            array('-1.5', 'number'),
-            array('109.5', 'number'),
-            array('.', 'dot'),
-            array('{', 'lbrace'),
-            array('}', 'rbrace'),
-            array('[', 'lbracket'),
-            array(']', 'rbracket'),
-            array(':', 'colon'),
-            array(',', 'comma'),
-            array('||', 'or'),
-            array('*', 'star'),
-            array('foo', 'identifier'),
-            array('"foo"', 'quoted_identifier'),
-            array('`true`', 'literal'),
-            array('`false`', 'literal'),
-            array('`null`', 'literal'),
-            array('`"true"`', 'literal')
-        );
+        return [
+            ['0', 'number'],
+            ['1', 'number'],
+            ['2', 'number'],
+            ['3', 'number'],
+            ['4', 'number'],
+            ['5', 'number'],
+            ['6', 'number'],
+            ['7', 'number'],
+            ['8', 'number'],
+            ['9', 'number'],
+            ['-1', 'number'],
+            ['-1.5', 'number'],
+            ['109.5', 'number'],
+            ['.', 'dot'],
+            ['{', 'lbrace'],
+            ['}', 'rbrace'],
+            ['[', 'lbracket'],
+            [']', 'rbracket'],
+            [':', 'colon'],
+            [',', 'comma'],
+            ['||', 'or'],
+            ['*', 'star'],
+            ['foo', 'identifier'],
+            ['"foo"', 'quoted_identifier'],
+            ['`true`', 'literal'],
+            ['`false`', 'literal'],
+            ['`null`', 'literal'],
+            ['`"true"`', 'literal']
+        ];
     }
 
     /**

--- a/tests/TreeInterpreterTest.php
+++ b/tests/TreeInterpreterTest.php
@@ -13,15 +13,15 @@ class TreeInterpreterTest extends TestCase
     public function testReturnsNullWhenMergingNonArray()
     {
         $t = new TreeInterpreter();
-        $this->assertNull($t->visit(array(
+        $this->assertNull($t->visit([
             'type' => 'flatten',
-            'children' => array(
-                array('type' => 'literal', 'value' => 1),
-                array('type' => 'literal', 'value' => 1)
-            )
-        ), array(), array(
+            'children' => [
+                ['type' => 'literal', 'value' => 1],
+                ['type' => 'literal', 'value' => 1]
+            ]
+        ], [], [
             'runtime' => new AstRuntime()
-        )));
+        ]));
     }
 
     public function testWorksWithArrayObjectAsObject()


### PR DESCRIPTION
Make sure src follows PSR-2, and let's use short array syntax everywhere. Looks like src uses short array syntax already, but not all of the tests.