### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.gitignore export-ignore
+/.gitattributes export-ignore
+/.travis.yml export-ignore
+/CHANGELOG.md export-ignore
+/Makefile export-ignore
+/phpunit.xml.dist export-ignore
+/tests export-ignore


### PR DESCRIPTION
The resources not intended for production should not be included in the Composer package since they unnecessarily increase the distribution package size and often become the source of security issues.