### PR TITLE
Don't gitignore changelog so it's kept with the distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,6 @@
 /.gitattributes export-ignore
 /.github export-ignore
 /.travis.yml export-ignore
-/CHANGELOG.md export-ignore
 /Makefile export-ignore
 /phpunit.xml.dist export-ignore
 /tests export-ignore


### PR DESCRIPTION
Similar to the README, a changelog should always be shipped with the software so the end-user has the most relevant information available.

I was just upgrading and tried checking the updated changelogs and noticed this one gone totally.

thanks!