### PR TITLE
Allow version 2.x for xdebug-handler dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
 
   "require-dev": {
-    "composer/xdebug-handler": "^1.4",
+    "composer/xdebug-handler": "^1.4 || ^2.0",
     "phpunit/phpunit": "^4.8.36 || ^7.5.15"
   },
 


### PR DESCRIPTION
`jmespath.php` is not affected by any of the breaking changes in current version `2.0` of `xdebug-handler`, so it is safe to allow both `v1.4` and `v2.0` as a dependency.

More info on the changes in `xdebug-handler` is listed in its [`UPGRADE.md`](https://github.com/composer/xdebug-handler/blob/61e11f49ee0f96727393bc95f872f02f3e68683e/UPGRADE.md).