### PR TITLE
Fix SyntaxErrorException throwing ValueError in PHP 8

### DIFF
--- a/src/SyntaxErrorException.php
+++ b/src/SyntaxErrorException.php
@@ -17,7 +17,7 @@ class SyntaxErrorException extends \InvalidArgumentException
         $expression
     ) {
         $message = "Syntax error at character {$token['pos']}\n"
-            . $expression . "\n" . str_repeat(' ', $token['pos']) . "^\n";
+            . $expression . "\n" . str_repeat(' ', max($token['pos'], 0)) . "^\n";
         $message .= !is_array($expectedTypesOrMessage)
             ? $expectedTypesOrMessage
             : $this->createTokenMessage($token, $expectedTypesOrMessage);

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -54,7 +54,7 @@ class ParserTest extends TestCase
      * @expectedException \JmesPath\SyntaxErrorException
      * @expectedExceptionMessag Syntax error at character 0
      */
-    public function testHandlesInvalidExpressions(string $expr)
+    public function testHandlesInvalidExpressions($expr)
     {
         (new Parser(new Lexer()))->parse($expr);
     }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -48,4 +48,24 @@ class ParserTest extends TestCase
     {
         (new Parser(new Lexer()))->parse('');
     }
+
+    /**
+     * @dataProvider invalidExpressionProvider
+     * @expectedException \JmesPath\SyntaxErrorException
+     * @expectedExceptionMessag Syntax error at character 0
+     */
+    public function testHandlesInvalidExpressions(string $expr)
+    {
+        (new Parser(new Lexer()))->parse($expr);
+    }
+
+    public function invalidExpressionProvider()
+    {
+        return [
+            ['='],
+            ['<'],
+            ['>'],
+            ['|']
+        ];
+    }
 }


### PR DESCRIPTION
This PR fixes #71 by ensuring that `$times` parameter of `str_repeat` is always positive.