### PR TITLE
Fix flattening in arrays starting with null

### DIFF
--- a/src/TreeCompiler.php
+++ b/src/TreeCompiler.php
@@ -305,7 +305,7 @@ class TreeCompiler
                 ->write('%s = [];', $merged)
                 ->write('foreach ($value as %s) {', $val)
                     ->indent()
-                    ->write('if (is_array(%s) && isset(%s[0])) {', $val, $val)
+                    ->write('if (is_array(%s) && array_key_exists(0, %s)) {', $val, $val)
                         ->indent()
                         ->write('%s = array_merge(%s, %s);', $merged, $merged, $val)
                         ->outdent()

--- a/src/TreeInterpreter.php
+++ b/src/TreeInterpreter.php
@@ -107,7 +107,7 @@ class TreeInterpreter
                 $merged = [];
                 foreach ($value as $values) {
                     // Only merge up arrays lists and not hashes
-                    if (is_array($values) && isset($values[0])) {
+                    if (is_array($values) && array_key_exists(0, $values)) {
                         $merged = array_merge($merged, $values);
                     } elseif ($values !== $skipElement) {
                         $merged[] = $values;

--- a/tests/compliance/indices.json
+++ b/tests/compliance/indices.json
@@ -298,6 +298,29 @@
     ]
 },
 {
+    "given":
+        {
+            "foo": [
+                {"bar": [null, null, 3, 5, 6, null]},
+                {"bar": [1, 3, null, 5]}
+            ]
+        },
+    "cases": [
+        {
+            "expression": "foo[*].bar",
+            "result": [[null, null, 3, 5, 6, null], [1, 3, null, 5]]
+        },
+        {
+            "expression": "foo[*].bar[*]",
+            "result": [[3, 5, 6], [1, 3, 5]]
+        },
+        {
+            "expression": "foo[*].bar[]",
+            "result": [3, 5, 6, 1, 3, 5]
+        }
+    ]
+},
+{
     "given": {
         "string": "string",
         "hash": {"foo": "bar", "bar": "baz"},

--- a/tests/compliance/wildcard.json
+++ b/tests/compliance/wildcard.json
@@ -456,5 +456,16 @@
             "result": [0, 0]
          }
      ]
+},
+{
+    "given": {
+        "foo": [null, 1, null, 2, null]
+    },
+    "cases": [
+        {
+            "expression": "foo[*]",
+            "result": [1, 2]
+        }
+    ]
 }
 ]


### PR DESCRIPTION
Current behaviour of the library when facing this scenario:

```json
{
    "foo": [
        {"bar": [null, null, 3, 5, 6, null]},
        {"bar": [1, 3, null, 5]}
     ]
}
```

```
foo[*].bar[]
```

is this:

```php
Array
(
    [0] => Array
        (
            [0] => 
            [1] => 
            [2] => 3
            [3] => 5
            [4] => 6
            [5] => 
        )

    [1] => 1
    [2] => 3
    [3] => 5
)

```

but **expected behaviour** would be this:

```php
Array
(
    [0] => 3
    [1] => 5
    [2] => 6
    [3] => 1
    [4] => 3
    [5] => 5
)
```

Demo on official Jmespath homepage:

![Screenshot 2022-08-25 at 12 34 01](https://user-images.githubusercontent.com/1840284/186642777-c019bb22-be41-45b7-813c-9915f8d0f466.png)

# Fix
The bug is caused by a "loose" `isset()` check, which makes a list array not be treated as a list array when the first position is `null` (i.e. `isset($array[0])` will evaluate to false, but that does not exclusively mean the array does not have a position 0).

(I noticed there is an existing Utils::isArray() method, so maybe it is better to use that instead of the change I made, but I was not sure that method was 100% intended for what we want to check in this particular case.)