### PR TITLE
Update Env.php to prevent Undefined global variable $_ENV

### DIFF
--- a/src/Env.php
+++ b/src/Env.php
@@ -76,11 +76,11 @@ final class Env
      */
     private static function getEnvVariable($name)
     {
-        if (array_key_exists($name, $_SERVER)) {
+        if (!empty($_SERVER) && array_key_exists($name, $_SERVER)) {
             return $_SERVER[$name];
         }
 
-        if (array_key_exists($name, $_ENV)) {
+        if (!empty($_ENV) && array_key_exists($name, $_ENV)) {
             return $_ENV[$name];
         }
 


### PR DESCRIPTION
I have $_ENV disabled on my server as I only need environment variables accessible from getenv(). Unfortunately using  array_key_exists() throws an error since $_ENV does not exist. So this commit resolves that.