### PR TITLE
Fix parser diagnostics

### DIFF
--- a/src/FnDispatcher.php
+++ b/src/FnDispatcher.php
@@ -272,7 +272,7 @@ class FnDispatcher
 
     private function fn_map(array $args)
     {
-        $this->validate('map', $args, [['expression'], ['any']]);
+        $this->validate('map', $args, [['expression'], ['array']]);
         $result = [];
         foreach ($args[1] as $a) {
             $result[] = $args[0]($a);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -22,6 +22,8 @@ class Parser
         T::T_EOF               => 0,
         T::T_QUOTED_IDENTIFIER => 0,
         T::T_IDENTIFIER        => 0,
+        T::T_UNKNOWN           => 0,
+        T::T_LITERAL           => 0,
         T::T_RBRACKET          => 0,
         T::T_RPAREN            => 0,
         T::T_COMMA             => 0,
@@ -272,6 +274,10 @@ class Parser
 
     private function led_lparen(array $left)
     {
+        if (!isset($left['value'])) {
+            throw $this->syntax('Invalid function name');
+        }
+
         $args = [];
         $this->next();
 

--- a/src/SyntaxErrorException.php
+++ b/src/SyntaxErrorException.php
@@ -16,6 +16,7 @@ class SyntaxErrorException extends \InvalidArgumentException
         array $token,
         $expression
     ) {
+        $token += ['pos' => mb_strlen($expression, 'UTF-8'), 'value' => null];
         $message = sprintf("Syntax error at character %d\n", max($token['pos'], 0))
             . $expression . "\n" . str_repeat(' ', max($token['pos'], 0)) . "^\n";
         $message .= !is_array($expectedTypesOrMessage)

--- a/tests/FnDispatcherTest.php
+++ b/tests/FnDispatcherTest.php
@@ -18,6 +18,17 @@ class fnDispatcherTest extends TestCase
         $this->assertEquals('foo', $fn('to_string', [new _TestStringClass()]));
         $this->assertEquals('"foo"', $fn('to_string', [new _TestJsonStringClass()]));
     }
+
+    public function testMapRequiresArraySecondArgument(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Argument 1 of map must be one of the following types: array. null found'
+        );
+
+        $fn = new FnDispatcher();
+        $fn('map', [function ($v) { return $v; }, null]);
+    }
 }
 
 class _TestStringClass

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -34,7 +34,51 @@ class ParserTest extends TestCase
             ['=', 'Syntax error at character 0'],
             ['<', 'Syntax error at character 0'],
             ['>', 'Syntax error at character 0'],
-            ['|', 'Syntax error at character 0']
+            ['|', 'Syntax error at character 0'],
+            ['@(foo)', 'Invalid function name'],
+            ['@=', 'Did not reach the end of the token stream'],
+            ['`1` `2`', 'Did not reach the end of the token stream'],
+            ['{a: @', 'Syntax error at character 5']
+        ];
+    }
+
+    /**
+     * @dataProvider invalidLedTokenProvider
+     */
+    public function testInvalidExpressionsThrowCleanSyntaxErrors(string $expr): void
+    {
+        $diags = [];
+        set_error_handler(function ($errno, $errstr) use (&$diags) {
+            $diags[] = $errstr;
+            return true;
+        });
+
+        try {
+            try {
+                (new Parser())->parse($expr);
+                $this->fail("Expected SyntaxErrorException for: $expr");
+            } catch (SyntaxErrorException $e) {
+                $this->assertStringContainsString('Syntax error at character', $e->getMessage());
+            }
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $diags, "PHP warnings/notices emitted while parsing: $expr");
+    }
+
+    public static function invalidLedTokenProvider(): array
+    {
+        return [
+            ['avg([].size)+'],
+            ['a = b'],
+            ['@ `1`'],
+            ['@``'],
+            ['foo[]+'],
+            ['foo#bar'],
+            ['@ `"`'],
+            ['+foo'],
+            ['"foo'],
         ];
     }
 }

--- a/tests/SyntaxErrorExceptionTest.php
+++ b/tests/SyntaxErrorExceptionTest.php
@@ -40,4 +40,11 @@ Expected one of the following: dot, eof; found comma ","
 EOT;
         $this->assertStringContainsString($expected, $e->getMessage());
     }
+
+    public function testDefaultsMissingTokenKeysToEndOfExpression(): void
+    {
+        $e = new SyntaxErrorException(['comma' => true], ['type' => 'eof'], 'abc');
+
+        $this->assertStringContainsString('Syntax error at character 3', $e->getMessage());
+    }
 }


### PR DESCRIPTION
This fixes several parser and function diagnostics that were previously masked by the compliance harness. Syntax errors now tolerate missing token metadata, unknown and literal tokens in led position stop without PHP warnings, non-field function call syntax fails during parsing, and map() requires an array second argument instead of iterating null. These changes make invalid expressions report the intended library exceptions without relying on PHP warnings.