### PR TITLE
Harden compliance test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 vendor
 composer.lock
 phpunit.xml
-compiled
 artifacts/

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ view-coverage:
 
 clean:
 	rm -rf artifacts/*
-	rm -rf compiled/*
 
 perf:
 	php bin/perf.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,11 @@
              convertDeprecationsToExceptions="true"
     >
 
+    <php>
+        <ini name="error_reporting" value="-1"/>
+        <ini name="display_errors" value="1"/>
+    </php>
+
     <testsuites>
         <testsuite name="Unit Tests">
             <directory>tests</directory>

--- a/tests/ComplianceTest.php
+++ b/tests/ComplianceTest.php
@@ -12,13 +12,17 @@ class ComplianceTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        self::$path = __DIR__ . '/../../compiled';
-        array_map('unlink', glob(self::$path . '/jmespath_*.php'));
+        self::$path = sys_get_temp_dir() . '/jmespath-compliance-compiled';
+        if (!is_dir(self::$path)) {
+            mkdir(self::$path, 0777, true);
+        }
+        array_map('unlink', glob(self::$path . '/jmespath_*.php') ?: []);
     }
 
     public static function tearDownAfterClass(): void
     {
-        array_map('unlink', glob(self::$path . '/jmespath_*.php'));
+        array_map('unlink', glob(self::$path . '/jmespath_*.php') ?: []);
+        @rmdir(self::$path);
     }
 
     /**
@@ -43,12 +47,14 @@ class ComplianceTest extends TestCase
 
         try {
             if ($compiled) {
-                $compiledStr = \JmesPath\Env::COMPILE_DIR . '=on ';
+                $compiledStr = \JmesPath\Env::COMPILE_DIR . '=' . self::$path . ' ';
                 $runtime = new CompilerRuntime(self::$path);
             } else {
                 $runtime = new AstRuntime();
             }
             $evalResult = $runtime($expression, $data);
+        } catch (\PHPUnit\Exception $e) {
+            throw $e;
         } catch (\Exception $e) {
             $failed = $e instanceof SyntaxErrorException ? 'syntax' : 'runtime';
             $failureMsg = sprintf(
@@ -69,6 +75,11 @@ class ComplianceTest extends TestCase
             $this->fail("Should not have failed\n{$failure}=> {$failed} {$failureMsg}");
         } elseif ($error && !$failed) {
             $this->fail("Should have failed\n{$failure}");
+        } elseif ($error) {
+            $expectedKind = $error === 'syntax' ? 'syntax' : 'runtime';
+            if ($failed !== $expectedKind) {
+                $this->fail("Expected {$expectedKind} ({$error}) but got {$failed}\n{$failure}");
+            }
         }
 
         $this->assertEquals(


### PR DESCRIPTION
This hardens the compliance test harness so PHPUnit-converted diagnostics are no longer swallowed as expected runtime errors. It also checks the expected syntax or runtime error kind, uses an isolated temporary compiled-cache directory, and pins PHPUnit's error reporting settings so local and CI runs enforce the same zero-diagnostics behavior.