### PR TITLE
Parse to_number strings strictly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 2.9.0 - Upcoming
+
+* Fixed to_number() to parse number strings using the JSON number grammar.
+* Fixed @(foo) to throw a syntax error.
+* Fixed PHP warnings emitted while parsing certain invalid expressions.
+* Fixed the caret position in syntax error messages for errors at the end of an expression.
+* Fixed map() to error on non-array second arguments instead of returning [].
+
 ## 2.8.0 - 2024-09-04
 
 * Add support for PHP 8.4.

--- a/src/FnDispatcher.php
+++ b/src/FnDispatcher.php
@@ -236,14 +236,53 @@ class FnDispatcher
     {
         $this->validateArity('to_number', count($args), 1);
         $value = $args[0];
-        $type = Utils::type($value);
-        if ($type == 'number') {
+
+        if (Utils::type($value) == 'number') {
             return $value;
-        } elseif ($type == 'string' && is_numeric($value)) {
-            return mb_strpos($value, '.', 0, 'UTF-8') ? (float) $value : (int) $value;
-        } else {
+        }
+
+        if (!is_string($value)) {
             return null;
         }
+
+        return $this->parseJsonNumber($value);
+    }
+
+    /**
+     * Parses a string conforming to the JSON number grammar (RFC 8259) into
+     * an int when exactly representable, otherwise a float. Returns null for
+     * non-conforming or non-finite input.
+     */
+    private function parseJsonNumber($value)
+    {
+        if (!preg_match('/^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?$/D', $value)) {
+            return null;
+        }
+
+        if (preg_match('/^-?(?:0|[1-9][0-9]*)$/D', $value)) {
+            return $this->parseJsonInteger($value);
+        }
+
+        $number = (float) $value;
+
+        return is_finite($number) ? $number : null;
+    }
+
+    private function parseJsonInteger($value)
+    {
+        $negative = $value[0] === '-';
+        $digits = $negative ? substr($value, 1) : $value;
+        $limit = $negative ? substr((string) PHP_INT_MIN, 1) : (string) PHP_INT_MAX;
+
+        if (strlen($digits) < strlen($limit)
+            || (strlen($digits) === strlen($limit) && strcmp($digits, $limit) <= 0)
+        ) {
+            return (int) $value;
+        }
+
+        $number = (float) $value;
+
+        return is_finite($number) ? $number : null;
     }
 
     private function fn_values(array $args)

--- a/tests/FnDispatcherTest.php
+++ b/tests/FnDispatcherTest.php
@@ -1,10 +1,10 @@
 <?php
 namespace JmesPath\Tests;
 
-use JmesPath\fnDispatcher;
+use JmesPath\FnDispatcher;
 use PHPUnit\Framework\TestCase;
 
-class fnDispatcherTest extends TestCase
+class FnDispatcherTest extends TestCase
 {
     public function testConvertsToString(): void
     {
@@ -28,6 +28,42 @@ class fnDispatcherTest extends TestCase
 
         $fn = new FnDispatcher();
         $fn('map', [function ($v) { return $v; }, null]);
+    }
+
+    /**
+     * @dataProvider toNumberProvider
+     */
+    public function testToNumberParsesJsonNumberStrings($input, $expected): void
+    {
+        $fn = new FnDispatcher();
+
+        $this->assertSame($expected, $fn('to_number', [$input]));
+    }
+
+    public static function toNumberProvider(): array
+    {
+        return [
+            ['1e2', 100.0],
+            ['1E+2', 100.0],
+            ['1E-2', 0.01],
+            ['1.5', 1.5],
+            ['4', 4],
+            ['-0', 0],
+            [(string) PHP_INT_MAX, PHP_INT_MAX],
+            [(string) PHP_INT_MIN, PHP_INT_MIN],
+            ['9223372036854775808', 9.223372036854776E+18],
+            ['+1', null],
+            ['01', null],
+            [' 1', null],
+            ['1 ', null],
+            ["1\n", null],
+            ['.5', null],
+            ['1.', null],
+            ['NaN', null],
+            ['INF', null],
+            ['0x1A', null],
+            ['1e10000', null],
+        ];
     }
 }
 


### PR DESCRIPTION
This changes to_number() so string inputs are parsed with the JSON number grammar instead of PHP's broader numeric-string rules. Existing numeric values are still returned unchanged, valid JSON-number strings produce ints when exactly representable and floats otherwise, and non-conforming or non-finite strings now return null. The dispatcher test class casing is also corrected, and the 2.9.0 changelog section is started with this fix and the parser diagnostics backfill.