### PR TITLE
Reject invalid index integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.9.0 - Upcoming
 
 * Fixed to_number() to parse number strings using the JSON number grammar.
-* Fixed @(foo) to throw a syntax error.
+* Fixed @(foo), foo[-] and oversized index literals to throw syntax errors.
 * Fixed PHP warnings emitted while parsing certain invalid expressions.
 * Fixed the caret position in syntax error messages for errors at the end of an expression.
 * Fixed map() to error on non-array second arguments instead of returning [].

--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -298,9 +298,10 @@ class Lexer
                     $buffer .= $current;
                     $current = next($chars);
                 } while ($current !== false && isset($this->numbers[$current]));
+                $value = $this->parseIndexNumber($buffer);
                 $tokens[] = [
-                    'type'  => self::T_NUMBER,
-                    'value' => (int)$buffer,
+                    'type'  => $value === null ? self::T_UNKNOWN : self::T_NUMBER,
+                    'value' => $value === null ? $buffer : $value,
                     'pos'   => $start
                 ];
 
@@ -415,6 +416,30 @@ class Lexer
         next($chars);
 
         return ['type' => $type, 'value' => $buffer, 'pos' => $position];
+    }
+
+    /**
+     * Parses a bare index/slice integer token ("-"? digit+). Returns null
+     * when the buffer is a lone "-" or the value cannot be represented as a
+     * PHP integer.
+     */
+    private function parseIndexNumber($buffer)
+    {
+        if ($buffer === '-') {
+            return null;
+        }
+
+        $negative = $buffer[0] === '-';
+        $digits = ltrim($negative ? substr($buffer, 1) : $buffer, '0') ?: '0';
+        $limit = $negative ? substr((string) PHP_INT_MIN, 1) : (string) PHP_INT_MAX;
+
+        if (strlen($digits) > strlen($limit)
+            || (strlen($digits) === strlen($limit) && strcmp($digits, $limit) > 0)
+        ) {
+            return null;
+        }
+
+        return (int) $buffer;
     }
 
     /**

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -86,4 +86,45 @@ class LexerTest extends TestCase
         $this->assertEquals('foo', $tokens[0]['value']);
         $this->assertEquals('literal', $tokens[0]['type']);
     }
+
+    public function testHugeIndexLiteralIsUnknownInsteadOfClamped(): void
+    {
+        $lexer = new Lexer();
+        $tokens = $lexer->tokenize('foo[999999999999999999999999999999999999999]');
+
+        $this->assertSame('identifier', $tokens[0]['type']);
+        $this->assertSame('lbracket', $tokens[1]['type']);
+        $this->assertSame('unknown', $tokens[2]['type']);
+    }
+
+    public function testBareMinusIndexIsUnknown(): void
+    {
+        $lexer = new Lexer();
+        $tokens = $lexer->tokenize('foo[-]');
+
+        $this->assertSame('unknown', $tokens[2]['type']);
+    }
+
+    public function testIndexIntegerBoundariesAndLeadingZeros(): void
+    {
+        $lexer = new Lexer();
+
+        $tokens = $lexer->tokenize('foo[' . PHP_INT_MAX . ']');
+        $this->assertSame(PHP_INT_MAX, $tokens[2]['value']);
+
+        $tokens = $lexer->tokenize('foo[' . PHP_INT_MIN . ']');
+        $this->assertSame(PHP_INT_MIN, $tokens[2]['value']);
+
+        $tokens = $lexer->tokenize('foo[' . PHP_INT_MAX . '0]');
+        $this->assertSame('unknown', $tokens[2]['type']);
+
+        $tokens = $lexer->tokenize('foo[' . PHP_INT_MIN . '0]');
+        $this->assertSame('unknown', $tokens[2]['type']);
+
+        $tokens = $lexer->tokenize('foo[0000000000000000000000007]');
+        $this->assertSame(7, $tokens[2]['value']);
+
+        $tokens = $lexer->tokenize('foo[-0]');
+        $this->assertSame(0, $tokens[2]['value']);
+    }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -38,7 +38,9 @@ class ParserTest extends TestCase
             ['@(foo)', 'Invalid function name'],
             ['@=', 'Did not reach the end of the token stream'],
             ['`1` `2`', 'Did not reach the end of the token stream'],
-            ['{a: @', 'Syntax error at character 5']
+            ['{a: @', 'Syntax error at character 5'],
+            ['foo[-]', 'Syntax error at character 4'],
+            ['foo[999999999999999999999999999999999999999]', 'Syntax error at character 4']
         ];
     }
 


### PR DESCRIPTION
This changes bracket integer tokenization so a bare minus sign and integer literals outside the native PHP integer range become syntax errors instead of being silently cast or clamped. Valid boundary values and leading-zero index literals continue to parse as before. The 2.9.0 changelog entry for syntax errors is updated to include these newly rejected index forms.