### PR TITLE
Harden compiled cache handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixed PHP warnings emitted while parsing certain invalid expressions.
 * Fixed the caret position in syntax error messages for errors at the end of an expression.
 * Fixed map() to error on non-array second arguments instead of returning [].
+* Fixed Env::cleanCompileDir() when JP_PHP_COMPILE=on.
 
 ## 2.8.0 - 2024-09-04
 

--- a/src/CompilerRuntime.php
+++ b/src/CompilerRuntime.php
@@ -8,11 +8,14 @@ namespace JmesPath;
  * logic to determine the filename:
  *
  * 1. Start with the string "jmespath_"
- * 2. Append the MD5 checksum of the expression.
+ * 2. Append the MD5 checksum of the expression salted with the PHP version
+ *    and compiled-cache epoch.
  * 3. Append ".php"
  */
 class CompilerRuntime
 {
+    const CACHE_VERSION = 2;
+
     private $parser;
     private $compiler;
     private $cacheDir;
@@ -51,7 +54,7 @@ class CompilerRuntime
      */
     public function __invoke($expression, $data)
     {
-        $functionName = 'jmespath_' . md5($expression);
+        $functionName = self::functionName($expression);
 
         if (!function_exists($functionName)) {
             $filename = "{$this->cacheDir}/{$functionName}.php";
@@ -64,6 +67,23 @@ class CompilerRuntime
         return $functionName($this->interpreter, $data);
     }
 
+    /**
+     * @internal Shared with DebugRuntime so cache naming cannot drift.
+     */
+    public static function functionName($expression)
+    {
+        return 'jmespath_' . md5(
+            'jmespath:' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION
+            . ':' . self::CACHE_VERSION . ':' . $expression
+        );
+    }
+
+    /** @internal */
+    public function getCacheDir()
+    {
+        return $this->cacheDir;
+    }
+
     private function compile($filename, $expression, $functionName)
     {
         $code = $this->compiler->visit(
@@ -72,12 +92,26 @@ class CompilerRuntime
             $expression
         );
 
-        if (!file_put_contents($filename, $code)) {
+        $tempFile = $filename . '.' . bin2hex(random_bytes(12)) . '.tmp';
+
+        if (!file_put_contents($tempFile, $code)) {
             throw new \RuntimeException(sprintf(
                 'Unable to write the compiled PHP code to: %s (%s)',
-                $filename,
+                $tempFile,
                 var_export(error_get_last(), true)
             ));
+        }
+
+        if (!rename($tempFile, $filename)) {
+            @unlink($tempFile);
+            if (!file_exists($filename)) {
+                throw new \RuntimeException(
+                    "Unable to move the compiled PHP code to: {$filename}"
+                );
+            }
+            // Another process won the race; its file is equivalent.
+        } elseif (function_exists('opcache_invalidate')) {
+            opcache_invalidate($filename, true);
         }
     }
 }

--- a/src/DebugRuntime.php
+++ b/src/DebugRuntime.php
@@ -83,12 +83,12 @@ class DebugRuntime
     private function dumpCompiledCode($expression)
     {
         fwrite($this->out, "Code\n========\n\n");
-        $dir = sys_get_temp_dir();
-        $hash = md5($expression);
-        $functionName = "jmespath_{$hash}";
-        $filename = "{$dir}/{$functionName}.php";
+        $functionName = CompilerRuntime::functionName($expression);
+        $filename = $this->runtime->getCacheDir() . '/' . $functionName . '.php';
         fwrite($this->out, "File: {$filename}\n\n");
-        fprintf($this->out, file_get_contents($filename));
+        fwrite($this->out, is_file($filename)
+            ? file_get_contents($filename)
+            : "(not present: {$functionName} was already loaded in this process, likely from another cache directory)\n");
     }
 
     private function debugCallback(callable $debugFn, $expression, $data)

--- a/src/Env.php
+++ b/src/Env.php
@@ -57,7 +57,10 @@ final class Env
     public static function cleanCompileDir()
     {
         $total = 0;
-        $compileDir = self::getEnvVariable(self::COMPILE_DIR) ?: sys_get_temp_dir();
+        $compileDir = self::getEnvVariable(self::COMPILE_DIR);
+        if ($compileDir === 'on' || !$compileDir) {
+            $compileDir = sys_get_temp_dir();
+        }
 
         foreach (glob("{$compileDir}/jmespath_*.php") as $file) {
             $total++;

--- a/tests/CompilerRuntimeTest.php
+++ b/tests/CompilerRuntimeTest.php
@@ -1,0 +1,52 @@
+<?php
+namespace JmesPath\Tests;
+
+use JmesPath\CompilerRuntime;
+use PHPUnit\Framework\TestCase;
+
+class CompilerRuntimeTest extends TestCase
+{
+    public function testCompiledFileUsesVersionedName(): void
+    {
+        $dir = $this->createTempDir();
+        $expr = 'field' . str_replace('.', '', uniqid('', true));
+        $runtime = new CompilerRuntime($dir);
+
+        try {
+            $this->assertSame(123, $runtime($expr, [$expr => 123]));
+
+            $filename = $dir . '/' . CompilerRuntime::functionName($expr) . '.php';
+            $this->assertFileExists($filename);
+            $this->assertEmpty(glob($dir . '/*.tmp') ?: []);
+            $this->assertSame(456, $runtime($expr, [$expr => 456]));
+        } finally {
+            $this->removeTempDir($dir);
+        }
+    }
+
+    public function testFunctionNameUsesVersionedSalt(): void
+    {
+        $this->assertSame(
+            'jmespath_' . md5(
+                'jmespath:' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . ':2:foo.bar'
+            ),
+            CompilerRuntime::functionName('foo.bar')
+        );
+    }
+
+    private function createTempDir()
+    {
+        $dir = sys_get_temp_dir() . '/jmespath-compiler-' . uniqid('', true);
+        mkdir($dir);
+
+        return realpath($dir);
+    }
+
+    private function removeTempDir($dir): void
+    {
+        foreach (glob($dir . '/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($dir);
+    }
+}

--- a/tests/DebugRuntimeTest.php
+++ b/tests/DebugRuntimeTest.php
@@ -1,0 +1,52 @@
+<?php
+namespace JmesPath\Tests;
+
+use JmesPath\CompilerRuntime;
+use JmesPath\DebugRuntime;
+use PHPUnit\Framework\TestCase;
+
+class DebugRuntimeTest extends TestCase
+{
+    public function testCompiledDebugOutputUsesCustomCacheDirAndPreservesPercents(): void
+    {
+        $dir = $this->createTempDir();
+        $key = 'x%sy%%z' . str_replace('.', '', uniqid('', true));
+        $expr = json_encode($key);
+        $out = fopen('php://memory', 'w+');
+
+        try {
+            $debug = new DebugRuntime(new CompilerRuntime($dir), $out);
+            $this->assertSame('value', $debug($expr, [$key => 'value']));
+
+            $filename = $dir . '/' . CompilerRuntime::functionName($expr) . '.php';
+            rewind($out);
+            $output = stream_get_contents($out);
+
+            $this->assertStringContainsString("File: {$filename}", $output);
+            $this->assertStringContainsString(file_get_contents($filename), $output);
+            $this->assertStringContainsString('%s', $output);
+            $this->assertStringContainsString('%%', $output);
+        } finally {
+            if (is_resource($out)) {
+                fclose($out);
+            }
+            $this->removeTempDir($dir);
+        }
+    }
+
+    private function createTempDir()
+    {
+        $dir = sys_get_temp_dir() . '/jmespath-debug-' . uniqid('', true);
+        mkdir($dir);
+
+        return realpath($dir);
+    }
+
+    private function removeTempDir($dir): void
+    {
+        foreach (glob($dir . '/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($dir);
+    }
+}

--- a/tests/EnvTest.php
+++ b/tests/EnvTest.php
@@ -29,4 +29,29 @@ class EnvTest extends TestCase
         $this->assertGreaterThan(0, Env::cleanCompileDir());
         $this->assertEmpty(glob($dir . '/jmespath_*.php'));
     }
+
+    public function testCleansCompileDirWhenCompileEnvIsOn(): void
+    {
+        $serverExists = array_key_exists(Env::COMPILE_DIR, $_SERVER);
+        $serverValue = $serverExists ? $_SERVER[Env::COMPILE_DIR] : null;
+        $_SERVER[Env::COMPILE_DIR] = 'on';
+
+        $expr = 'env' . str_replace('.', '', uniqid('', true));
+        $filename = sys_get_temp_dir() . '/' . CompilerRuntime::functionName($expr) . '.php';
+        $runtime = new CompilerRuntime(sys_get_temp_dir());
+
+        try {
+            $this->assertSame(1, $runtime($expr, [$expr => 1]));
+            $this->assertFileExists($filename);
+            $this->assertGreaterThan(0, Env::cleanCompileDir());
+            $this->assertFileNotExists($filename);
+        } finally {
+            @unlink($filename);
+            if ($serverExists) {
+                $_SERVER[Env::COMPILE_DIR] = $serverValue;
+            } else {
+                unset($_SERVER[Env::COMPILE_DIR]);
+            }
+        }
+    }
 }


### PR DESCRIPTION
This hardens compiled cache handling by adding versioned cache names, writing compiled files through same-directory temporary files before renaming them into place, and invalidating OPcache after successful writes. Debug output now reads from the runtime's actual cache directory without treating compiled source as a printf format string, and Env::cleanCompileDir() now cleans the temp cache correctly when JP_PHP_COMPILE=on.