### PR TITLE
Apply JMESPath truthiness in the compiled runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.9.0 - Upcoming
 
 * Fixed to_number() to parse number strings using the JSON number grammar.
+* Fixed the compiled runtime to apply JMESPath truthiness to || and &&.
 * Fixed @(foo), foo[-] and oversized index literals to throw syntax errors.
 * Fixed PHP warnings emitted while parsing certain invalid expressions.
 * Fixed the caret position in syntax error messages for errors at the end of an expression.

--- a/src/CompilerRuntime.php
+++ b/src/CompilerRuntime.php
@@ -14,7 +14,7 @@ namespace JmesPath;
  */
 class CompilerRuntime
 {
-    const CACHE_VERSION = 2;
+    const CACHE_VERSION = 3;
 
     private $parser;
     private $compiler;

--- a/src/TreeCompiler.php
+++ b/src/TreeCompiler.php
@@ -107,7 +107,7 @@ class TreeCompiler
         return $this
             ->write('%s = $value;', $a)
             ->dispatch($node['children'][0])
-            ->write('if (!$value && $value !== "0" && $value !== 0) {')
+            ->write('if (!Utils::isTruthy($value)) {')
                 ->indent()
                 ->write('$value = %s;', $a)
                 ->dispatch($node['children'][1])
@@ -121,7 +121,7 @@ class TreeCompiler
         return $this
             ->write('%s = $value;', $a)
             ->dispatch($node['children'][0])
-            ->write('if ($value || $value === "0" || $value === 0) {')
+            ->write('if (Utils::isTruthy($value)) {')
                 ->indent()
                 ->write('$value = %s;', $a)
                 ->dispatch($node['children'][1])

--- a/tests/CompilerRuntimeTest.php
+++ b/tests/CompilerRuntimeTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace JmesPath\Tests;
 
+use JmesPath\AstRuntime;
 use JmesPath\CompilerRuntime;
 use PHPUnit\Framework\TestCase;
 
@@ -9,7 +10,7 @@ class CompilerRuntimeTest extends TestCase
     public function testCompiledFileUsesVersionedName(): void
     {
         $dir = $this->createTempDir();
-        $expr = 'field' . str_replace('.', '', uniqid('', true));
+        $expr = 'field' . bin2hex(random_bytes(12));
         $runtime = new CompilerRuntime($dir);
 
         try {
@@ -28,15 +29,36 @@ class CompilerRuntimeTest extends TestCase
     {
         $this->assertSame(
             'jmespath_' . md5(
-                'jmespath:' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . ':2:foo.bar'
+                'jmespath:' . PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . ':3:foo.bar'
             ),
             CompilerRuntime::functionName('foo.bar')
         );
     }
 
+    public function testRuntimesUseJmesPathTruthinessForEmptyObjects(): void
+    {
+        $dir = $this->createTempDir();
+
+        try {
+            foreach ([new AstRuntime(), new CompilerRuntime($dir)] as $runtime) {
+                $this->assertSame('x', $runtime('empty_hash || fallback', [
+                    'empty_hash' => new \stdClass(),
+                    'fallback' => 'x',
+                ]));
+
+                $this->assertEquals(new \stdClass(), $runtime('empty_hash && fallback', [
+                    'empty_hash' => new \stdClass(),
+                    'fallback' => 'x',
+                ]));
+            }
+        } finally {
+            $this->removeTempDir($dir);
+        }
+    }
+
     private function createTempDir()
     {
-        $dir = sys_get_temp_dir() . '/jmespath-compiler-' . uniqid('', true);
+        $dir = sys_get_temp_dir() . '/jmespath-compiler-' . bin2hex(random_bytes(12));
         mkdir($dir);
 
         return realpath($dir);


### PR DESCRIPTION
This fixes the compiled runtime to evaluate || and && with the same JMESPath truthiness rules as the AST runtime. It bumps the compiled cache epoch so existing generated functions are recompiled, and adds a parity test for empty object operands.