### PR TITLE
Use random entropy in cache tests

### DIFF
--- a/tests/DebugRuntimeTest.php
+++ b/tests/DebugRuntimeTest.php
@@ -10,7 +10,7 @@ class DebugRuntimeTest extends TestCase
     public function testCompiledDebugOutputUsesCustomCacheDirAndPreservesPercents(): void
     {
         $dir = $this->createTempDir();
-        $key = 'x%sy%%z' . str_replace('.', '', uniqid('', true));
+        $key = 'x%sy%%z' . bin2hex(random_bytes(12));
         $expr = json_encode($key);
         $out = fopen('php://memory', 'w+');
 
@@ -36,7 +36,7 @@ class DebugRuntimeTest extends TestCase
 
     private function createTempDir()
     {
-        $dir = sys_get_temp_dir() . '/jmespath-debug-' . uniqid('', true);
+        $dir = sys_get_temp_dir() . '/jmespath-debug-' . bin2hex(random_bytes(12));
         mkdir($dir);
 
         return realpath($dir);

--- a/tests/EnvTest.php
+++ b/tests/EnvTest.php
@@ -36,7 +36,7 @@ class EnvTest extends TestCase
         $serverValue = $serverExists ? $_SERVER[Env::COMPILE_DIR] : null;
         $_SERVER[Env::COMPILE_DIR] = 'on';
 
-        $expr = 'env' . str_replace('.', '', uniqid('', true));
+        $expr = 'env' . bin2hex(random_bytes(12));
         $filename = sys_get_temp_dir() . '/' . CompilerRuntime::functionName($expr) . '.php';
         $runtime = new CompilerRuntime(sys_get_temp_dir());
 


### PR DESCRIPTION
This replaces the remaining uniqid-based entropy in the debug and environment cache tests with bin2hex(random_bytes(12)). The tests no longer rely on timestamp-based identifiers for generated expression names or temporary directory suffixes.