### PR TITLE
Fix UTF-8 reverse and slicing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2.9.0 - Upcoming
 
 * Fixed to_number() to parse number strings using the JSON number grammar.
+* Fixed reverse() and string slicing to operate on UTF-8 characters rather than bytes.
+* Fixed slicing of array-like (ArrayAccess + Countable) values.
 * Fixed the compiled runtime to apply JMESPath truthiness to || and &&.
 * Fixed @(foo), foo[-] and oversized index literals to throw syntax errors.
 * Fixed PHP warnings emitted while parsing certain invalid expressions.

--- a/src/FnDispatcher.php
+++ b/src/FnDispatcher.php
@@ -162,7 +162,7 @@ class FnDispatcher
         if (is_array($args[0])) {
             return array_reverse($args[0]);
         } elseif (is_string($args[0])) {
-            return strrev($args[0]);
+            return implode('', array_reverse(mb_str_split($args[0], 1, 'UTF-8')));
         } else {
             throw new \RuntimeException('Cannot reverse provided argument');
         }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -192,7 +192,7 @@ class Utils
      */
     public static function slice($value, $start = null, $stop = null, $step = 1)
     {
-        if (!is_array($value) && !is_string($value)) {
+        if (!is_string($value) && !self::isArray($value)) {
             throw new \InvalidArgumentException('Expects string or array');
         }
 
@@ -239,7 +239,10 @@ class Utils
     private static function sliceIndices($subject, $start, $stop, $step)
     {
         $type = gettype($subject);
-        $len = $type == 'string' ? mb_strlen($subject, 'UTF-8') : count($subject);
+        if ($type == 'string') {
+            $subject = mb_str_split($subject, 1, 'UTF-8');
+        }
+        $len = count($subject);
         list($start, $stop, $step) = self::adjustSlice($len, $start, $stop, $step);
 
         $result = [];

--- a/tests/FnDispatcherTest.php
+++ b/tests/FnDispatcherTest.php
@@ -30,6 +30,14 @@ class FnDispatcherTest extends TestCase
         $fn('map', [function ($v) { return $v; }, null]);
     }
 
+    public function testReversesUtf8Strings(): void
+    {
+        $fn = new FnDispatcher();
+
+        $this->assertSame('aé', $fn('reverse', ['éa']));
+        $this->assertSame('☃ba', $fn('reverse', ['ab☃']));
+    }
+
     /**
      * @dataProvider toNumberProvider
      */

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace JmesPath\Tests;
 
+use JmesPath\AstRuntime;
 use JmesPath\Utils;
 use PHPUnit\Framework\TestCase;
 
@@ -110,6 +111,31 @@ class UtilsTest extends TestCase
         $this->assertEquals('cba', Utils::slice('abc', null, null, -1));
         $this->assertEquals('ac', Utils::slice('abc', null, null, 2));
         $this->assertEquals('bc', Utils::slice('abc', 1));
+    }
+
+    public function testSlicesUtf8Strings(): void
+    {
+        $this->assertSame('é', Utils::slice('éa', 0, 1));
+        $this->assertSame('cbaé', Utils::slice('éabc', null, null, -1));
+    }
+
+    public function testSlicesArrayAccessCountable(): void
+    {
+        $this->assertSame([1, 2], Utils::slice(new \ArrayObject([1, 2, 3]), 0, 2));
+    }
+
+    public function testRejectsObjectLikeValuesInSlice(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Utils::slice(new \ArrayObject(['foo' => 'bar']), 0, 1);
+    }
+
+    public function testRuntimeSlicesArrayAccessCountable(): void
+    {
+        $runtime = new AstRuntime();
+
+        $this->assertSame([1, 2], $runtime('[0:2]', new \ArrayObject([1, 2, 3])));
     }
 }
 


### PR DESCRIPTION
This fixes reverse() and string slicing to operate on UTF-8 characters instead of raw bytes. It also lets Utils::slice() handle array-like ArrayAccess and Countable values consistently with the runtimes while continuing to reject object-like values.