### PR TITLE
Use JSON semantics for equality and contains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixed to_number() to parse number strings using the JSON number grammar.
 * Fixed reverse() and string slicing to operate on UTF-8 characters rather than bytes.
 * Fixed slicing of array-like (ArrayAccess + Countable) values.
+* Fixed equality and contains() to use JSON semantics, e.g. 1 == 1.0 is now true.
 * Fixed the compiled runtime to apply JMESPath truthiness to || and &&.
 * Fixed @(foo), foo[-] and oversized index literals to throw syntax errors.
 * Fixed PHP warnings emitted while parsing certain invalid expressions.

--- a/src/FnDispatcher.php
+++ b/src/FnDispatcher.php
@@ -60,12 +60,18 @@ class FnDispatcher
     {
         $this->validate('contains', $args, [['string', 'array'], ['any']]);
         if (is_array($args[0])) {
-            return in_array($args[1], $args[0]);
-        } elseif (is_string($args[1])) {
-            return mb_strpos($args[0], $args[1], 0, 'UTF-8') !== false;
-        } else {
-            return null;
+            foreach ($args[0] as $value) {
+                if (Utils::isEqual($value, $args[1])) {
+                    return true;
+                }
+            }
+
+            return false;
         }
+
+        return is_string($args[1])
+            ? mb_strpos($args[0], $args[1], 0, 'UTF-8') !== false
+            : false;
     }
 
     private function fn_ends_with(array $args)

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -106,7 +106,10 @@ class Utils
     }
 
     /**
-     * JSON aware value comparison function.
+     * JSON-semantic equality: one number type, structural comparison for arrays
+     * and objects, and no object key-order sensitivity.
+     * Empty arrays and empty objects compare equal because PHP cannot represent
+     * that distinction after associative JSON decoding.
      *
      * @param mixed $a First value to compare
      * @param mixed $b Second value to compare
@@ -115,15 +118,38 @@ class Utils
      */
     public static function isEqual($a, $b)
     {
-        if ($a === $b) {
-            return true;
-        } elseif ($a instanceof \stdClass) {
-            return self::isEqual((array) $a, $b);
-        } elseif ($b instanceof \stdClass) {
-            return self::isEqual($a, (array) $b);
-        } else {
-            return false;
+        $typeA = self::type($a);
+        $typeB = self::type($b);
+
+        if ($typeA !== $typeB) {
+            return ($typeA === 'array' || $typeA === 'object')
+                && ($typeB === 'array' || $typeB === 'object')
+                && (array) $a === []
+                && (array) $b === [];
         }
+
+        if ($typeA === 'number') {
+            return $a == $b;
+        }
+
+        if ($typeA === 'array' || $typeA === 'object') {
+            $a = (array) $a;
+            $b = (array) $b;
+
+            if (count($a) !== count($b)) {
+                return false;
+            }
+
+            foreach ($a as $key => $value) {
+                if (!array_key_exists($key, $b) || !self::isEqual($value, $b[$key])) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return $a === $b;
     }
 
     /**

--- a/tests/CompilerRuntimeTest.php
+++ b/tests/CompilerRuntimeTest.php
@@ -56,6 +56,19 @@ class CompilerRuntimeTest extends TestCase
         }
     }
 
+    public function testRuntimesUseJsonSemanticEqualityForNumbers(): void
+    {
+        $dir = $this->createTempDir();
+
+        try {
+            foreach ([new AstRuntime(), new CompilerRuntime($dir)] as $runtime) {
+                $this->assertTrue($runtime('`1` == `1.0`', null));
+            }
+        } finally {
+            $this->removeTempDir($dir);
+        }
+    }
+
     private function createTempDir()
     {
         $dir = sys_get_temp_dir() . '/jmespath-compiler-' . bin2hex(random_bytes(12));

--- a/tests/FnDispatcherTest.php
+++ b/tests/FnDispatcherTest.php
@@ -38,6 +38,17 @@ class FnDispatcherTest extends TestCase
         $this->assertSame('☃ba', $fn('reverse', ['ab☃']));
     }
 
+    public function testContainsUsesJsonSemantics(): void
+    {
+        $fn = new FnDispatcher();
+
+        $this->assertFalse($fn('contains', [[1, 2, 3], '2']));
+        $this->assertFalse($fn('contains', [['1', 8], 1]));
+        $this->assertTrue($fn('contains', [[1, 2], 2.0]));
+        $this->assertTrue($fn('contains', [[['a' => 1]], (object) ['a' => 1]]));
+        $this->assertFalse($fn('contains', ['foobar', 123]));
+    }
+
     /**
      * @dataProvider toNumberProvider
      */

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -99,6 +99,23 @@ class UtilsTest extends TestCase
         $this->assertEquals(0, $result[4]);
     }
 
+    public function testComparesValuesUsingJsonSemantics(): void
+    {
+        $this->assertTrue(Utils::isEqual(1, 1.0));
+        $this->assertTrue(Utils::isEqual(['a' => 1], (object) ['a' => 1.0]));
+        $this->assertTrue(Utils::isEqual(
+            (object) ['a' => (object) ['b' => 1]],
+            (object) ['a' => (object) ['b' => 1]]
+        ));
+        $this->assertTrue(Utils::isEqual(['a' => 1, 'b' => 2], ['b' => 2, 'a' => 1]));
+        $this->assertTrue(Utils::isEqual([], new \stdClass()));
+        $this->assertFalse(Utils::isEqual(['a' => 1], ['a' => 2]));
+        $this->assertFalse(Utils::isEqual([1], [1, 1]));
+        $this->assertFalse(Utils::isEqual('1', 1));
+        $this->assertFalse(Utils::isEqual(1, true));
+        $this->assertFalse(Utils::isEqual(0, null));
+    }
+
     public function testSlicesArrays(): void
     {
         $this->assertEquals([3, 2, 1], Utils::slice([1, 2, 3], null, null, -1));


### PR DESCRIPTION
This fixes equality to use JSON-style semantics, including one numeric type and recursive structural comparison without object key-order sensitivity. contains() now uses the same comparator for arrays and returns false, not null, when a string subject is searched with a non-string value. Empty arrays and empty objects still compare equal because PHP cannot distinguish them after associative JSON decoding, and numeric-string-keyed object behavior remains unchanged.