### PR TITLE
Fix max and min ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Fixed reverse() and string slicing to operate on UTF-8 characters rather than bytes.
 * Fixed slicing of array-like (ArrayAccess + Countable) values.
 * Fixed equality and contains() to use JSON semantics, e.g. 1 == 1.0 is now true.
+* Changed max(), min(), max_by() and min_by() to order strings by code point.
+* Fixed max_by() and min_by() to error on mixed-type keys instead of returning arbitrary elements.
+* Fixed max() returning null or erroring when the first array element is falsy, e.g. max([0, 1]).
 * Fixed the compiled runtime to apply JMESPath truthiness to || and &&.
 * Fixed @(foo), foo[-] and oversized index literals to throw syntax errors.
 * Fixed PHP warnings emitted while parsing certain invalid expressions.

--- a/src/FnDispatcher.php
+++ b/src/FnDispatcher.php
@@ -124,8 +124,8 @@ class FnDispatcher
     private function fn_max(array $args)
     {
         $this->validate('max', $args, [['array']]);
-        $fn = function ($a, $b) {
-            return $a >= $b ? $a : $b;
+        $fn = function ($a, $b, $i) {
+            return $i && self::compareValues($a, $b) >= 0 ? $a : $b;
         };
         return $this->reduce('max:0', $args[0], ['number', 'string'], $fn);
     }
@@ -134,10 +134,21 @@ class FnDispatcher
     {
         $this->validate('max_by', $args, [['array'], ['expression']]);
         $expr = $this->wrapExpression('max_by:1', $args[1], ['number', 'string']);
-        $fn = function ($carry, $item, $index) use ($expr) {
-            return $index
-                ? ($expr($carry) >= $expr($item) ? $carry : $item)
-                : $item;
+        $carryKey = null;
+        $fn = function ($carry, $item, $index) use ($expr, &$carryKey) {
+            if (!$index) {
+                return $item;
+            }
+            if ($index === 1) {
+                $carryKey = $expr($carry);
+            }
+            $itemKey = $expr($item);
+            $this->validateSeq('max_by:0', ['number', 'string'], $carryKey, $itemKey);
+            if (self::compareValues($carryKey, $itemKey) >= 0) {
+                return $carry;
+            }
+            $carryKey = $itemKey;
+            return $item;
         };
         return $this->reduce('max_by:1', $args[0], ['any'], $fn);
     }
@@ -146,7 +157,7 @@ class FnDispatcher
     {
         $this->validate('min', $args, [['array']]);
         $fn = function ($a, $b, $i) {
-            return $i && $a <= $b ? $a : $b;
+            return $i && self::compareValues($a, $b) <= 0 ? $a : $b;
         };
         return $this->reduce('min:0', $args[0], ['number', 'string'], $fn);
     }
@@ -155,9 +166,21 @@ class FnDispatcher
     {
         $this->validate('min_by', $args, [['array'], ['expression']]);
         $expr = $this->wrapExpression('min_by:1', $args[1], ['number', 'string']);
-        $i = -1;
-        $fn = function ($a, $b) use ($expr, &$i) {
-            return ++$i ? ($expr($a) <= $expr($b) ? $a : $b) : $b;
+        $carryKey = null;
+        $fn = function ($carry, $item, $index) use ($expr, &$carryKey) {
+            if (!$index) {
+                return $item;
+            }
+            if ($index === 1) {
+                $carryKey = $expr($carry);
+            }
+            $itemKey = $expr($item);
+            $this->validateSeq('min_by:0', ['number', 'string'], $carryKey, $itemKey);
+            if (self::compareValues($carryKey, $itemKey) <= 0) {
+                return $carry;
+            }
+            $carryKey = $itemKey;
+            return $item;
         };
         return $this->reduce('min_by:1', $args[0], ['any'], $fn);
     }
@@ -397,6 +420,21 @@ class FnDispatcher
                 . "Found {$ta}, {$tb}.";
             $this->typeError($from, $msg);
         }
+    }
+
+    /**
+     * Compares two values of the same JMESPath type.
+     *
+     * @param mixed $a Value A
+     * @param mixed $b Value B
+     *
+     * @return int Negative if $a < $b, zero if equal, positive if $a > $b.
+     */
+    private static function compareValues($a, $b)
+    {
+        return Utils::type($a) === 'string'
+            ? strcmp((string) $a, (string) $b)
+            : ($a <=> $b);
     }
 
     /**

--- a/tests/FnDispatcherTest.php
+++ b/tests/FnDispatcherTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace JmesPath\Tests;
 
+use JmesPath\Env;
 use JmesPath\FnDispatcher;
 use PHPUnit\Framework\TestCase;
 
@@ -47,6 +48,129 @@ class FnDispatcherTest extends TestCase
         $this->assertTrue($fn('contains', [[1, 2], 2.0]));
         $this->assertTrue($fn('contains', [[['a' => 1]], (object) ['a' => 1]]));
         $this->assertFalse($fn('contains', ['foobar', 123]));
+    }
+
+    public function testMaxAndMinCompareStringsByCodePoint(): void
+    {
+        $fn = new FnDispatcher();
+
+        $this->assertSame('9', $fn('max', [['10', '9']]));
+        $this->assertSame('1', $fn('max', [['01', '1']]));
+        $this->assertSame('50', $fn('max', [['1e2', '50']]));
+        $this->assertSame('10', $fn('min', [['10', '9']]));
+        $this->assertSame('01', $fn('min', [['01', '1']]));
+        $this->assertSame('1e2', $fn('min', [['1e2', '50']]));
+    }
+
+    public function testMaxByAndMinByCompareStringKeysByCodePoint(): void
+    {
+        $fn = new FnDispatcher();
+        $expr = function ($item) { return $item['k']; };
+
+        $this->assertSame(['k' => '9'], $fn('max_by', [[['k' => '10'], ['k' => '9']], $expr]));
+        $this->assertSame(['k' => '10'], $fn('min_by', [[['k' => '10'], ['k' => '9']], $expr]));
+    }
+
+    public function testMaxHandlesFalsyFirstElements(): void
+    {
+        $fn = new FnDispatcher();
+
+        $this->assertSame(1, $fn('max', [[0, 1]]));
+        $this->assertSame(0, $fn('max', [[0]]));
+        $this->assertSame('', $fn('max', [['']]));
+        $this->assertSame('1', $fn('max', [['0', '1']]));
+        $this->assertSame(10, $fn('max', [[2.5, 10, 2]]));
+    }
+
+    /**
+     * @dataProvider mixedKeyFunctionProvider
+     */
+    public function testMaxByAndMinByRejectMixedKeyTypes(string $fnName): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            "Argument 0 of {$fnName} encountered a type mismatch in sequence: number, string"
+        );
+
+        $fn = new FnDispatcher();
+        $fn($fnName, [[['k' => 1], ['k' => 'a']], function ($item) { return $item['k']; }]);
+    }
+
+    public static function mixedKeyFunctionProvider(): array
+    {
+        return [['max_by'], ['min_by']];
+    }
+
+    public function testMaxMixedTypesKeepsTheExactMasterMessage(): void
+    {
+        try {
+            (new FnDispatcher())('max', [[1, 'a']]);
+            $this->fail('Expected a RuntimeException');
+        } catch (\RuntimeException $e) {
+            $this->assertSame(
+                'Argument 0 of max encountered a type mismatch in sequence: number, string',
+                $e->getMessage()
+            );
+        }
+    }
+
+    public function testMaxByAndMinByReturnFirstElementWhenKeysAreEqual(): void
+    {
+        $fn = new FnDispatcher();
+        $expr = function ($item) { return $item['k']; };
+        $first = ['k' => 1, 'name' => 'first'];
+        $second = ['k' => 1, 'name' => 'second'];
+
+        $this->assertSame($first, $fn('max_by', [[$first, $second], $expr]));
+        $this->assertSame($first, $fn('min_by', [[$first, $second], $expr]));
+    }
+
+    public function testMaxByComparesSurvivingCarryKeyAgain(): void
+    {
+        $fn = new FnDispatcher();
+        $expr = function ($item) { return $item['k']; };
+
+        $this->assertSame(['k' => 3], $fn('max_by', [[['k' => 3], ['k' => 1], ['k' => 2]], $expr]));
+    }
+
+    public function testMaxByEvaluatesKeyExpressionOncePerElement(): void
+    {
+        $fn = new FnDispatcher();
+        $calls = 0;
+        $expr = function ($item) use (&$calls) { $calls++; return $item['k']; };
+
+        $fn('max_by', [[['k' => 1], ['k' => 3], ['k' => 2]], $expr]);
+
+        $this->assertSame(3, $calls);
+    }
+
+    public function testMinByEvaluatesKeyExpressionOncePerElement(): void
+    {
+        $fn = new FnDispatcher();
+        $calls = 0;
+        $expr = function ($item) use (&$calls) { $calls++; return $item['k']; };
+
+        $fn('min_by', [[['k' => 3], ['k' => 1], ['k' => 2]], $expr]);
+
+        $this->assertSame(3, $calls);
+    }
+
+    public function testSearchUsesCodePointOrderingForMaxFunctions(): void
+    {
+        $data = [['k' => '10'], ['k' => '9']];
+
+        $this->assertSame('9', Env::search('max(@)', ['10', '9']));
+        $this->assertSame(['k' => '9'], Env::search('max_by(@, &k)', $data));
+    }
+
+    public function testMaxComparesStringableObjectsByCodePoint(): void
+    {
+        $fn = new FnDispatcher();
+        $low = new _TestComparableString('10');
+        $high = new _TestComparableString('9');
+
+        $this->assertSame($high, $fn('max', [[$low, $high]]));
+        $this->assertSame($low, $fn('min', [[$low, $high]]));
     }
 
     /**
@@ -104,5 +228,20 @@ class _TestJsonStringClass implements \JsonSerializable
     public function jsonSerialize(): string
     {
         return 'foo';
+    }
+}
+
+class _TestComparableString
+{
+    private $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
     }
 }


### PR DESCRIPTION
This fixes #95, fixes #96, and fixes #98 by comparing max and min string values by code point, rejecting mixed max_by and min_by key types, and preserving falsy first values in max(). The by-key functions now evaluate each key at most once while keeping the previous single-element laziness. Invalid inputs can surface more accurate type errors, and stale compiled caches pick up the change through the runtime dispatcher without recompilation.