### PR TITLE
Fix sort comparators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 * Fixed reverse() and string slicing to operate on UTF-8 characters rather than bytes.
 * Fixed slicing of array-like (ArrayAccess + Countable) values.
 * Fixed equality and contains() to use JSON semantics, e.g. 1 == 1.0 is now true.
-* Changed max(), min(), max_by() and min_by() to order strings by code point.
+* Fixed sort() and sort_by() to compare numbers numerically.
+* Changed sort(), sort_by(), max(), min(), max_by() and min_by() to order strings by code point.
 * Fixed max_by() and min_by() to error on mixed-type keys instead of returning arbitrary elements.
 * Fixed max() returning null or erroring when the first array element is falsy, e.g. max([0, 1]).
 * Fixed the compiled runtime to apply JMESPath truthiness to || and &&.

--- a/src/FnDispatcher.php
+++ b/src/FnDispatcher.php
@@ -212,7 +212,7 @@ class FnDispatcher
         $valid = ['string', 'number'];
         return Utils::stableSort($args[0], function ($a, $b) use ($valid) {
             $this->validateSeq('sort:0', $valid, $a, $b);
-            return strnatcmp($a, $b);
+            return self::compareValues($a, $b);
         });
     }
 
@@ -227,7 +227,7 @@ class FnDispatcher
                 $va = $expr($a);
                 $vb = $expr($b);
                 $this->validateSeq('sort_by:0', $valid, $va, $vb);
-                return strnatcmp($va, $vb);
+                return self::compareValues($va, $vb);
             }
         );
     }

--- a/tests/CompilerRuntimeTest.php
+++ b/tests/CompilerRuntimeTest.php
@@ -69,6 +69,23 @@ class CompilerRuntimeTest extends TestCase
         }
     }
 
+    public function testCompiledRuntimeSortsNumerically(): void
+    {
+        $dir = $this->createTempDir();
+
+        try {
+            $runtime = new CompilerRuntime($dir);
+            $this->assertSame([-2, -1, 3], $runtime('sort(@)', [-1, -2, 3]));
+            $data = json_decode(
+                '{"values":[{"v":"A","w":0.63554},{"v":"B","w":0.20155},{"v":"C","w":0.6058}]}',
+                true
+            );
+            $this->assertSame(['B', 'C', 'A'], $runtime('sort_by(values, &w)[].v', $data));
+        } finally {
+            $this->removeTempDir($dir);
+        }
+    }
+
     private function createTempDir()
     {
         $dir = sys_get_temp_dir() . '/jmespath-compiler-' . bin2hex(random_bytes(12));

--- a/tests/FnDispatcherTest.php
+++ b/tests/FnDispatcherTest.php
@@ -173,6 +173,55 @@ class FnDispatcherTest extends TestCase
         $this->assertSame($low, $fn('min', [[$low, $high]]));
     }
 
+    public function testSortComparesNumbersNumerically(): void
+    {
+        $fn = FnDispatcher::getInstance();
+
+        $this->assertSame([0.20155, 0.6058, 0.63554], $fn('sort', [[0.6058, 0.20155, 0.63554]]));
+        $this->assertSame([-2, -1, 3], $fn('sort', [[-1, -2, 3]]));
+        $this->assertSame([5, 1.0E+20], $fn('sort', [[1.0E+20, 5]]));
+        $this->assertSame([2, 2.5, 10], $fn('sort', [[2.5, 10, 2]]));
+    }
+
+    public function testSortComparesStringsByCodePoint(): void
+    {
+        $fn = FnDispatcher::getInstance();
+
+        $this->assertSame(['x1', 'x10', 'x2'], $fn('sort', [['x10', 'x2', 'x1']]));
+        $this->assertSame(['10', '2', '9'], $fn('sort', [['10', '9', '2']]));
+        $this->assertSame(['001', '01', '1'], $fn('sort', [['1', '01', '001']]));
+    }
+
+    public function testSortByOrdersFloatKeysNumerically(): void
+    {
+        $data = json_decode(
+            '{"values":[{"i32_lv2":"A","f_weight":0.63554},{"i32_lv2":"B","f_weight":0.20155},{"i32_lv2":"C","f_weight":0.6058}]}',
+            true
+        );
+
+        $this->assertSame(['B', 'C', 'A'], Env::search('sort_by(values, &to_number(f_weight))[].i32_lv2', $data));
+        $this->assertSame(['B', 'C', 'A'], Env::search('sort_by(values, &f_weight)[].i32_lv2', $data));
+    }
+
+    public function testSortByIsStableForEqualKeys(): void
+    {
+        $data = [
+            ['k' => 1, 'n' => 'third'],
+            ['k' => 0, 'n' => 'first'],
+            ['k' => 0, 'n' => 'second'],
+        ];
+
+        $this->assertSame(['first', 'second', 'third'], Env::search('sort_by(@, &k)[].n', $data));
+    }
+
+    public function testSortMixedTypesStillThrows(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('type mismatch in sequence: number, string');
+
+        FnDispatcher::getInstance()('sort', [[1, 'a']]);
+    }
+
     /**
      * @dataProvider toNumberProvider
      */


### PR DESCRIPTION
This fixes #88 by making sort() and sort_by() compare numbers numerically and strings by code point. The change reuses the comparator introduced for max and min, and stale compiled caches pick up the new behavior through the runtime dispatcher without recompilation.