### PR TITLE
Fix cleanup backlog

### DIFF
--- a/bin/jp.php
+++ b/bin/jp.php
@@ -21,7 +21,7 @@ Provide the JSON input and expression:
     echo '{}' | jp.php expression
 
 Or provide the path to a compliance script, a suite, and test case number:
-    jp.php --script path_to_script --suite test_suite_number --case test_case_number [expression]
+    jp.php --file path_to_compliance_json --suite test_suite_number --case test_case_number [expression]
 
 EOT;
 
@@ -58,7 +58,7 @@ if (isset($args['file']) || isset($args['suite']) || isset($args['case'])) {
         if (isset($set['cases'][$args['case']]['result'])) {
             echo json_encode($set['cases'][$args['case']]['result'], JSON_PRETTY_PRINT) . "\n\n";
         } elseif (isset($set['cases'][$args['case']]['error'])) {
-            echo "{$set['cases'][$argv['case']]['error']} error\n\n";
+            echo "{$set['cases'][$args['case']]['error']} error\n\n";
         } else {
             echo "NULL\n\n";
         }

--- a/src/AstRuntime.php
+++ b/src/AstRuntime.php
@@ -9,7 +9,6 @@ class AstRuntime
     private $parser;
     private $interpreter;
     private $cache = [];
-    private $cachedCount = 0;
 
     public function __construct(
         ?Parser $parser = null,
@@ -34,10 +33,9 @@ class AstRuntime
     public function __invoke($expression, $data)
     {
         if (!isset($this->cache[$expression])) {
-            // Clear the AST cache when it hits 1024 entries
-            if (++$this->cachedCount > 1024) {
+            // Clear the AST cache when it already holds 1024 entries.
+            if (count($this->cache) >= 1024) {
                 $this->cache = [];
-                $this->cachedCount = 0;
             }
             $this->cache[$expression] = $this->parser->parse($expression);
         }

--- a/src/TreeCompiler.php
+++ b/src/TreeCompiler.php
@@ -332,7 +332,7 @@ class TreeCompiler
             ->write('');
 
         if (!isset($node['from'])) {
-            $this->write('if (!is_array($value) || !($value instanceof \stdClass)) { $value = null; }');
+            $this->write('if (!is_array($value) && !($value instanceof \stdClass)) { $value = null; }');
         } elseif ($node['from'] == 'object') {
             $this->write('if (!Utils::isObject($value)) { $value = null; }');
         } elseif ($node['from'] == 'array') {

--- a/src/TreeInterpreter.php
+++ b/src/TreeInterpreter.php
@@ -69,7 +69,8 @@ class TreeInterpreter
 
             case 'projection':
                 $left = $this->dispatch($node['children'][0], $value);
-                switch ($node['from']) {
+                $from = isset($node['from']) ? $node['from'] : null;
+                switch ($from) {
                     case 'object':
                         if (!Utils::isObject($left)) {
                             return null;
@@ -81,7 +82,7 @@ class TreeInterpreter
                         }
                         break;
                     default:
-                        if (!is_array($left) || !($left instanceof \stdClass)) {
+                        if (!is_array($left) && !($left instanceof \stdClass)) {
                             return null;
                         }
                 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -58,12 +58,18 @@ class Utils
             return count($arg) == 0 || $arg->offsetExists(0)
                 ? 'array'
                 : 'object';
-        } elseif (method_exists($arg, '__toString')) {
-            return 'string';
+        } elseif (is_object($arg)) {
+            if (method_exists($arg, '__toString')) {
+                return 'string';
+            }
+
+            throw new \InvalidArgumentException(
+                'Unable to determine JMESPath type from ' . get_class($arg)
+            );
         }
 
         throw new \InvalidArgumentException(
-            'Unable to determine JMESPath type from ' . get_class($arg)
+            'Unable to determine JMESPath type from ' . gettype($arg)
         );
     }
 

--- a/tests/AstRuntimeTest.php
+++ b/tests/AstRuntimeTest.php
@@ -1,0 +1,57 @@
+<?php
+namespace JmesPath\Tests;
+
+use JmesPath\AstRuntime;
+use JmesPath\SyntaxErrorException;
+use PHPUnit\Framework\TestCase;
+
+class AstRuntimeTest extends TestCase
+{
+    public function testAstCacheNeverExceedsCap(): void
+    {
+        $runtime = new AstRuntime();
+        $cache = new \ReflectionProperty(AstRuntime::class, 'cache');
+        $cache->setAccessible(true);
+        $data = ['x' => 1];
+
+        for ($i = 1; $i <= 2100; $i++) {
+            $runtime('k' . $i, $data);
+            $this->assertLessThanOrEqual(
+                1024,
+                count($cache->getValue($runtime)),
+                "AST cache exceeded 1024 entries after expression #{$i}"
+            );
+        }
+    }
+
+    public function testReturnsIdenticalResultsAcrossCacheWipe(): void
+    {
+        $runtime = new AstRuntime();
+        $data = ['foo' => ['bar' => 42]];
+        $before = $runtime('foo.bar', $data);
+
+        for ($i = 1; $i <= 1100; $i++) {
+            $runtime('k' . $i, ['x' => 1]);
+        }
+
+        $this->assertSame(42, $before);
+        $this->assertSame($before, $runtime('foo.bar', $data));
+    }
+
+    public function testSyntaxErrorsDoNotEvictCachedEntries(): void
+    {
+        $runtime = new AstRuntime();
+        $cache = new \ReflectionProperty(AstRuntime::class, 'cache');
+        $cache->setAccessible(true);
+
+        $this->assertSame(1, $runtime('a', ['a' => 1]));
+        for ($i = 1; $i <= 1100; $i++) {
+            try {
+                $runtime('!!bad' . $i . '!!', []);
+            } catch (SyntaxErrorException $e) {
+            }
+        }
+
+        $this->assertArrayHasKey('a', $cache->getValue($runtime));
+    }
+}

--- a/tests/CliTest.php
+++ b/tests/CliTest.php
@@ -1,0 +1,55 @@
+<?php
+namespace JmesPath\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class CliTest extends TestCase
+{
+    public function testComplianceErrorCaseUsesFileOption(): void
+    {
+        $file = sys_get_temp_dir() . '/jmespath-cli-' . bin2hex(random_bytes(12)) . '.json';
+        file_put_contents($file, json_encode([
+            [
+                'given' => ['foo' => 'bar'],
+                'cases' => [
+                    [
+                        'expression' => 'foo',
+                        'error' => 'syntax',
+                    ],
+                ],
+            ],
+        ]));
+
+        try {
+            $command = sprintf(
+                '%s %s --file %s --suite 0 --case 0 2>&1',
+                escapeshellarg(PHP_BINARY),
+                escapeshellarg(__DIR__ . '/../bin/jp.php'),
+                escapeshellarg($file)
+            );
+            exec($command, $output, $status);
+
+            $this->assertSame(0, $status, implode("\n", $output));
+            $output = implode("\n", $output);
+            $this->assertStringContainsString('syntax error', $output);
+            $this->assertStringNotContainsString('Undefined array key', $output);
+        } finally {
+            @unlink($file);
+        }
+    }
+
+    public function testUsageMentionsFileOption(): void
+    {
+        $command = sprintf(
+            '%s %s 2>&1',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg(__DIR__ . '/../bin/jp.php')
+        );
+        exec($command, $output, $status);
+
+        $this->assertSame(0, $status, implode("\n", $output));
+        $output = implode("\n", $output);
+        $this->assertStringContainsString('--file path_to_compliance_json', $output);
+        $this->assertStringNotContainsString('--script', $output);
+    }
+}

--- a/tests/TreeCompilerTest.php
+++ b/tests/TreeCompilerTest.php
@@ -21,4 +21,25 @@ class TreeCompilerTest extends TestCase
         $this->assertStringContainsString('$value = isset($value->{\'foo\'}) ? $value->{\'foo\'} : null;', $source);
         $this->assertStringContainsString('$value = isset($value[\'foo\']) ? $value[\'foo\'] : null;', $source);
     }
+
+    public function testFromlessProjectionUsesCorrectGuard(): void
+    {
+        $t = new TreeCompiler();
+        $source = $t->visit(
+            [
+                'type' => 'projection',
+                'children' => [
+                    ['type' => 'current'],
+                    ['type' => 'current'],
+                ],
+            ],
+            'testing',
+            '[*]'
+        );
+
+        $this->assertStringContainsString(
+            'if (!is_array($value) && !($value instanceof \\stdClass)) { $value = null; }',
+            $source
+        );
+    }
 }

--- a/tests/TreeInterpreterTest.php
+++ b/tests/TreeInterpreterTest.php
@@ -24,6 +24,20 @@ class TreeInterpreterTest extends TestCase
         ]));
     }
 
+    public function testFromlessProjectionReturnsNullForNonArraysWithoutDiagnostics(): void
+    {
+        $t = new TreeInterpreter();
+
+        $this->assertNull($t->visit($this->fromlessProjection(), 1));
+    }
+
+    public function testFromlessProjectionTraversesArrays(): void
+    {
+        $t = new TreeInterpreter();
+
+        $this->assertSame([1, 2, 3], $t->visit($this->fromlessProjection(), [1, 2, 3]));
+    }
+
     public function testWorksWithArrayObjectAsObject(): void
     {
         $runtime = new AstRuntime();
@@ -68,5 +82,16 @@ class TreeInterpreterTest extends TestCase
                 ])
             ]))
         );
+    }
+
+    private function fromlessProjection(): array
+    {
+        return [
+            'type' => 'projection',
+            'children' => [
+                ['type' => 'current'],
+                ['type' => 'current'],
+            ],
+        ];
     }
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -2,6 +2,7 @@
 namespace JmesPath\Tests;
 
 use JmesPath\AstRuntime;
+use JmesPath\Env;
 use JmesPath\Utils;
 use PHPUnit\Framework\TestCase;
 
@@ -40,6 +41,37 @@ class UtilsTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         Utils::type(new _TestClass());
+    }
+
+    public function testThrowsInvalidArgumentForPlainObjects(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Utils::type(new _TestPlainClass());
+    }
+
+    public function testThrowsInvalidArgumentForResources(): void
+    {
+        $resource = fopen('php://memory', 'r');
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            Utils::type($resource);
+        } finally {
+            fclose($resource);
+        }
+    }
+
+    public function testTypeFunctionThrowsInvalidArgumentForResources(): void
+    {
+        $resource = fopen('php://memory', 'r');
+
+        try {
+            $this->expectException(\InvalidArgumentException::class);
+            Env::search('type(@)', $resource);
+        } finally {
+            fclose($resource);
+        }
     }
 
     public static function isArrayProvider(): array
@@ -171,4 +203,8 @@ class _TestStr
     {
         return '100';
     }
+}
+
+class _TestPlainClass
+{
 }


### PR DESCRIPTION
This fixes the small cleanup backlog and closes #92. It corrects the compliance CLI option text and error-case lookup, hardens from-less projection handling in the interpreter and compiler, makes Utils::type() report resources with InvalidArgumentException instead of TypeError, and replaces the AST cache counter with the cache size so syntax errors no longer cause premature wipes.