### PR TITLE
Add PHP 8.5 CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Checkout Code
@@ -21,7 +21,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: composer:snapshot
+          tools: composer
           coverage: none
 
       - name: Setup Problem Matchers
@@ -37,13 +37,45 @@ jobs:
       - name: Execute PHPUnit
         run: vendor/bin/phpunit
 
+  tests_opcache:
+    name: PHP ${{ matrix.php }} OPcache
+    runs-on: ubuntu-24.04
+
+    strategy:
+      matrix:
+        php: ['7.2', '8.5']
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer
+          coverage: none
+
+      - name: Setup Problem Matchers
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Install PHP Dependencies
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          command: composer update --no-interaction --no-progress
+
+      - name: Execute PHPUnit
+        run: php -d opcache.enable_cli=1 vendor/bin/phpunit
+
   tests_windows:
     name: PHP ${{ matrix.php }} Windows
     runs-on: windows-2025
 
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Configure Git
@@ -58,7 +90,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: composer:snapshot
+          tools: composer
           coverage: none
 
       - name: Setup Problem Matchers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.9.0 - Upcoming
 
+* Added PHP 8.5 support.
 * Fixed to_number() to parse number strings using the JSON number grammar.
 * Fixed reverse() and string slicing to operate on UTF-8 characters rather than bytes.
 * Fixed slicing of array-like (ArrayAccess + Countable) values.

--- a/tests/AstRuntimeTest.php
+++ b/tests/AstRuntimeTest.php
@@ -11,7 +11,9 @@ class AstRuntimeTest extends TestCase
     {
         $runtime = new AstRuntime();
         $cache = new \ReflectionProperty(AstRuntime::class, 'cache');
-        $cache->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $cache->setAccessible(true);
+        }
         $data = ['x' => 1];
 
         for ($i = 1; $i <= 2100; $i++) {
@@ -42,7 +44,9 @@ class AstRuntimeTest extends TestCase
     {
         $runtime = new AstRuntime();
         $cache = new \ReflectionProperty(AstRuntime::class, 'cache');
-        $cache->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $cache->setAccessible(true);
+        }
 
         $this->assertSame(1, $runtime('a', ['a' => 1]));
         for ($i = 1; $i <= 1100; $i++) {


### PR DESCRIPTION
This adds PHP 8.5 to the Linux and Windows CI matrices and adds a separate OPcache job for PHP 7.2 and PHP 8.5. It switches setup-php to the stable Composer tool, records PHP 8.5 support in the changelog, and avoids the PHP 8.5 ReflectionProperty::setAccessible deprecation in the AST cache tests.